### PR TITLE
Implement Address, Invoice and Route resources

### DIFF
--- a/src/addresses/addresses.controller.ts
+++ b/src/addresses/addresses.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Query,
+  ParseUUIDPipe,
+  ParseIntPipe,
+  UseInterceptors,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { AddressesService } from './addresses.service';
+import { CacheInterceptor } from '@nestjs/cache-manager';
+import { Ressources } from '@prisma/client';
+import { Resource } from 'lib/decorators/ressource-decorator';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
+import { PermissionsGuard } from 'src/auth/guards/RBACGuard';
+import { CreateAddressDto } from 'prisma/src/generated/dto/create-address.dto';
+import { UpdateAddressDto } from 'prisma/src/generated/dto/update-address.dto';
+import { AddressDto } from 'prisma/src/generated/dto/address.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { MAX_PAGE_SIZE } from 'lib/constants';
+
+@Controller('addresses')
+@UseInterceptors(CacheInterceptor)
+@Resource(Ressources.ADDRESS)
+@ApiInternalServerErrorResponse({ description: 'Internal server error' })
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@ApiForbiddenResponse({
+  description:
+    'Role does not have the permissions to perform this action on the requested ressource',
+})
+export class AddressesController {
+  constructor(private readonly addressesService: AddressesService) {}
+
+  @Post()
+  @ApiBody({ type: CreateAddressDto })
+  @ApiOkResponse({ type: AddressDto })
+  create(@Body() createAddressDto: CreateAddressDto) {
+    return this.addressesService.create(createAddressDto);
+  }
+
+  @Get()
+  @ApiQuery({ name: 'limit', type: Number, required: false, default: 10, maximum: MAX_PAGE_SIZE })
+  @ApiQuery({ name: 'page', type: Number, required: false, default: 1 })
+  @ApiOkResponse({ type: PagingResultDto<AddressDto> })
+  findAll(
+    @Query('limit', ParseIntPipe) limit = 10,
+    @Query('page', ParseIntPipe) page = 1,
+  ) {
+    if (limit > MAX_PAGE_SIZE) {
+      throw new BadRequestException(`Limit cannot exceed ${MAX_PAGE_SIZE}`);
+    }
+    return this.addressesService.findAll(limit, page);
+  }
+
+  @Get(':id')
+  @ApiParam({ name: 'id', type: String })
+  @ApiOkResponse({ type: AddressDto })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.addressesService.findById(id);
+  }
+
+  @Patch(':id')
+  @ApiParam({ name: 'id', type: String })
+  @ApiBody({ type: UpdateAddressDto })
+  @ApiOkResponse({ type: AddressDto })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateAddressDto: UpdateAddressDto,
+  ) {
+    return this.addressesService.update(id, updateAddressDto);
+  }
+}

--- a/src/addresses/addresses.module.ts
+++ b/src/addresses/addresses.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AddressesService } from './addresses.service';
+import { AddressesController } from './addresses.controller';
+import { AddressesRepository } from './addresses.repository';
+
+@Module({
+  controllers: [AddressesController],
+  providers: [AddressesService, AddressesRepository],
+})
+export class AddressesModule {}

--- a/src/addresses/addresses.repository.ts
+++ b/src/addresses/addresses.repository.ts
@@ -1,0 +1,60 @@
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { CustomPrismaService } from 'nestjs-prisma';
+import { ExtendedPrismaClient } from 'prisma/prisma.extension';
+import { CreateAddressDto } from 'prisma/src/generated/dto/create-address.dto';
+import { AddressDto } from 'prisma/src/generated/dto/address.dto';
+import { UpdateAddressDto } from 'prisma/src/generated/dto/update-address.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { transformResponse } from 'lib/utils/transform';
+import { isNoChange } from 'lib/utils/isNoChange';
+
+@Injectable()
+export class AddressesRepository {
+  constructor(
+    @Inject('PrismaService')
+    private prismaService: CustomPrismaService<ExtendedPrismaClient>,
+  ) {}
+
+  async create(data: CreateAddressDto): Promise<AddressDto> {
+    const address = await this.prismaService.client.address.create({ data });
+    return transformResponse(AddressDto, address);
+  }
+
+  async findAll(limit = 10, page = 1): Promise<PagingResultDto<AddressDto>> {
+    const [addresses, meta] = await this.prismaService.client.address
+      .paginate({ where: { deleted: false } })
+      .withPages({ limit, page, includePageCount: true });
+
+    return {
+      data: addresses.map((a: AddressDto) => transformResponse(AddressDto, a)),
+      meta,
+    };
+  }
+
+  async findById(addressId: string): Promise<AddressDto> {
+    const address = await this.prismaService.client.address.findUnique({
+      where: { addressId },
+    });
+    if (!address) {
+      throw new NotFoundException(`Address with ID ${addressId} not found`);
+    }
+    return transformResponse(AddressDto, address);
+  }
+
+  async update(addressId: string, data: UpdateAddressDto): Promise<AddressDto> {
+    const existing = await this.prismaService.client.address.findUnique({
+      where: { addressId },
+    });
+    if (!existing) {
+      throw new NotFoundException(`Address with ID ${addressId} not found`);
+    }
+    if (isNoChange<UpdateAddressDto>(data, existing)) {
+      throw new BadRequestException(`No changes detected for address ${addressId}`);
+    }
+    const address = await this.prismaService.client.address.update({
+      where: { addressId },
+      data,
+    });
+    return transformResponse(AddressDto, address);
+  }
+}

--- a/src/addresses/addresses.service.ts
+++ b/src/addresses/addresses.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { AddressesRepository } from './addresses.repository';
+import { CreateAddressDto } from 'prisma/src/generated/dto/create-address.dto';
+import { UpdateAddressDto } from 'prisma/src/generated/dto/update-address.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { AddressDto } from 'prisma/src/generated/dto/address.dto';
+
+@Injectable()
+export class AddressesService {
+  constructor(private readonly addressesRepository: AddressesRepository) {}
+
+  create(createAddressDto: CreateAddressDto): Promise<AddressDto> {
+    return this.addressesRepository.create(createAddressDto);
+  }
+
+  findAll(limit = 10, page = 1): Promise<PagingResultDto<AddressDto>> {
+    return this.addressesRepository.findAll(limit, page);
+  }
+
+  findById(id: string): Promise<AddressDto> {
+    return this.addressesRepository.findById(id);
+  }
+
+  update(id: string, updateAddressDto: UpdateAddressDto): Promise<AddressDto> {
+    return this.addressesRepository.update(id, updateAddressDto);
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,9 @@ import { OrdersModule } from './orders/orders.module';
 import { ProductsModule } from './products/products.module';
 import { FileRepositoryModule } from './file-repository/file-repository.module';
 import { ConfigModule } from '@nestjs/config';
+import { AddressesModule } from './addresses/addresses.module';
+import { InvoicesModule } from './invoices/invoices.module';
+import { RoutesModule } from './routes/routes.module';
 
 @Module({
   imports: [
@@ -67,6 +70,9 @@ import { ConfigModule } from '@nestjs/config';
     OrdersModule,
     ProductsModule,
     FileRepositoryModule,
+    AddressesModule,
+    InvoicesModule,
+    RoutesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/invoices/dto/create-invoice.dto.ts
+++ b/src/invoices/dto/create-invoice.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID, IsInt, IsOptional, IsDateString, IsString } from 'class-validator';
+
+export class CreateInvoiceDto {
+  @ApiProperty({ type: String, format: 'uuid' })
+  @IsUUID()
+  orderId: string;
+
+  @ApiProperty({ type: Number })
+  @IsInt()
+  invoiceAmount: number;
+
+  @ApiProperty({ type: String, format: 'date-time', required: false })
+  @IsOptional()
+  @IsDateString()
+  paymentDate?: Date;
+
+  @ApiProperty({ type: String })
+  @IsString()
+  pdfUrl: string;
+}

--- a/src/invoices/dto/update-invoice.dto.ts
+++ b/src/invoices/dto/update-invoice.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateInvoiceDto } from './create-invoice.dto';
+
+export class UpdateInvoiceDto extends PartialType(CreateInvoiceDto) {}

--- a/src/invoices/invoices.controller.ts
+++ b/src/invoices/invoices.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Query,
+  ParseUUIDPipe,
+  ParseIntPipe,
+  UseInterceptors,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { InvoicesService } from './invoices.service';
+import { CacheInterceptor } from '@nestjs/cache-manager';
+import { Ressources } from '@prisma/client';
+import { Resource } from 'lib/decorators/ressource-decorator';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
+import { PermissionsGuard } from 'src/auth/guards/RBACGuard';
+import { CreateInvoiceDto } from './dto/create-invoice.dto';
+import { UpdateInvoiceDto } from './dto/update-invoice.dto';
+import { InvoiceDto } from 'prisma/src/generated/dto/invoice.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { MAX_PAGE_SIZE } from 'lib/constants';
+
+@Controller('invoices')
+@UseInterceptors(CacheInterceptor)
+@Resource(Ressources.INVOICE)
+@ApiInternalServerErrorResponse({ description: 'Internal server error' })
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@ApiForbiddenResponse({
+  description:
+    'Role does not have the permissions to perform this action on the requested ressource',
+})
+export class InvoicesController {
+  constructor(private readonly invoicesService: InvoicesService) {}
+
+  @Post()
+  @ApiBody({ type: CreateInvoiceDto })
+  @ApiOkResponse({ type: InvoiceDto })
+  create(@Body() createInvoiceDto: CreateInvoiceDto) {
+    return this.invoicesService.create(createInvoiceDto);
+  }
+
+  @Get()
+  @ApiQuery({ name: 'limit', type: Number, required: false, default: 10, maximum: MAX_PAGE_SIZE })
+  @ApiQuery({ name: 'page', type: Number, required: false, default: 1 })
+  @ApiOkResponse({ type: PagingResultDto<InvoiceDto> })
+  findAll(
+    @Query('limit', ParseIntPipe) limit = 10,
+    @Query('page', ParseIntPipe) page = 1,
+  ) {
+    if (limit > MAX_PAGE_SIZE) {
+      throw new BadRequestException(`Limit cannot exceed ${MAX_PAGE_SIZE}`);
+    }
+    return this.invoicesService.findAll(limit, page);
+  }
+
+  @Get(':id')
+  @ApiParam({ name: 'id', type: String })
+  @ApiOkResponse({ type: InvoiceDto })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.invoicesService.findById(id);
+  }
+
+  @Patch(':id')
+  @ApiParam({ name: 'id', type: String })
+  @ApiBody({ type: UpdateInvoiceDto })
+  @ApiOkResponse({ type: InvoiceDto })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateInvoiceDto: UpdateInvoiceDto,
+  ) {
+    return this.invoicesService.update(id, updateInvoiceDto);
+  }
+}

--- a/src/invoices/invoices.module.ts
+++ b/src/invoices/invoices.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { InvoicesService } from './invoices.service';
+import { InvoicesController } from './invoices.controller';
+import { InvoicesRepository } from './invoices.repository';
+
+@Module({
+  controllers: [InvoicesController],
+  providers: [InvoicesService, InvoicesRepository],
+})
+export class InvoicesModule {}

--- a/src/invoices/invoices.repository.ts
+++ b/src/invoices/invoices.repository.ts
@@ -1,0 +1,66 @@
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { CustomPrismaService } from 'nestjs-prisma';
+import { ExtendedPrismaClient } from 'prisma/prisma.extension';
+import { CreateInvoiceDto } from './dto/create-invoice.dto';
+import { UpdateInvoiceDto } from './dto/update-invoice.dto';
+import { InvoiceDto } from 'prisma/src/generated/dto/invoice.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { transformResponse } from 'lib/utils/transform';
+import { isNoChange } from 'lib/utils/isNoChange';
+
+@Injectable()
+export class InvoicesRepository {
+  constructor(
+    @Inject('PrismaService')
+    private prismaService: CustomPrismaService<ExtendedPrismaClient>,
+  ) {}
+
+  async create(data: CreateInvoiceDto): Promise<InvoiceDto> {
+    const existing = await this.prismaService.client.invoice.findUnique({
+      where: { orderId: data.orderId },
+    });
+    if (existing) {
+      throw new BadRequestException(`Invoice for this order already exists`);
+    }
+    const invoice = await this.prismaService.client.invoice.create({ data });
+    return transformResponse(InvoiceDto, invoice);
+  }
+
+  async findAll(limit = 10, page = 1): Promise<PagingResultDto<InvoiceDto>> {
+    const [invoices, meta] = await this.prismaService.client.invoice
+      .paginate({ where: { deleted: false } })
+      .withPages({ limit, page, includePageCount: true });
+
+    return {
+      data: invoices.map((i: InvoiceDto) => transformResponse(InvoiceDto, i)),
+      meta,
+    };
+  }
+
+  async findById(invoiceId: string): Promise<InvoiceDto> {
+    const invoice = await this.prismaService.client.invoice.findUnique({
+      where: { invoiceId },
+    });
+    if (!invoice) {
+      throw new NotFoundException(`Invoice with ID ${invoiceId} not found`);
+    }
+    return transformResponse(InvoiceDto, invoice);
+  }
+
+  async update(invoiceId: string, data: UpdateInvoiceDto): Promise<InvoiceDto> {
+    const existing = await this.prismaService.client.invoice.findUnique({
+      where: { invoiceId },
+    });
+    if (!existing) {
+      throw new NotFoundException(`Invoice with ID ${invoiceId} not found`);
+    }
+    if (isNoChange<UpdateInvoiceDto>(data, existing)) {
+      throw new BadRequestException(`No changes detected for invoice ${invoiceId}`);
+    }
+    const invoice = await this.prismaService.client.invoice.update({
+      where: { invoiceId },
+      data,
+    });
+    return transformResponse(InvoiceDto, invoice);
+  }
+}

--- a/src/invoices/invoices.service.ts
+++ b/src/invoices/invoices.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InvoicesRepository } from './invoices.repository';
+import { CreateInvoiceDto } from './dto/create-invoice.dto';
+import { UpdateInvoiceDto } from './dto/update-invoice.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { InvoiceDto } from 'prisma/src/generated/dto/invoice.dto';
+
+@Injectable()
+export class InvoicesService {
+  constructor(private readonly invoicesRepository: InvoicesRepository) {}
+
+  create(createInvoiceDto: CreateInvoiceDto): Promise<InvoiceDto> {
+    return this.invoicesRepository.create(createInvoiceDto);
+  }
+
+  findAll(limit = 10, page = 1): Promise<PagingResultDto<InvoiceDto>> {
+    return this.invoicesRepository.findAll(limit, page);
+  }
+
+  findById(id: string): Promise<InvoiceDto> {
+    return this.invoicesRepository.findById(id);
+  }
+
+  update(id: string, updateInvoiceDto: UpdateInvoiceDto): Promise<InvoiceDto> {
+    return this.invoicesRepository.update(id, updateInvoiceDto);
+  }
+}

--- a/src/routes/routes.controller.ts
+++ b/src/routes/routes.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Query,
+  ParseUUIDPipe,
+  ParseIntPipe,
+  UseInterceptors,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { RoutesService } from './routes.service';
+import { CacheInterceptor } from '@nestjs/cache-manager';
+import { Ressources } from '@prisma/client';
+import { Resource } from 'lib/decorators/ressource-decorator';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
+import { PermissionsGuard } from 'src/auth/guards/RBACGuard';
+import { CreateRouteDto } from 'prisma/src/generated/dto/create-route.dto';
+import { UpdateRouteDto } from 'prisma/src/generated/dto/update-route.dto';
+import { RouteDto } from 'prisma/src/generated/dto/route.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { MAX_PAGE_SIZE } from 'lib/constants';
+
+@Controller('routes')
+@UseInterceptors(CacheInterceptor)
+@Resource(Ressources.ROUTES)
+@ApiInternalServerErrorResponse({ description: 'Internal server error' })
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@ApiForbiddenResponse({
+  description:
+    'Role does not have the permissions to perform this action on the requested ressource',
+})
+export class RoutesController {
+  constructor(private readonly routesService: RoutesService) {}
+
+  @Post()
+  @ApiBody({ type: CreateRouteDto })
+  @ApiOkResponse({ type: RouteDto })
+  create(@Body() createRouteDto: CreateRouteDto) {
+    return this.routesService.create(createRouteDto);
+  }
+
+  @Get()
+  @ApiQuery({ name: 'limit', type: Number, required: false, default: 10, maximum: MAX_PAGE_SIZE })
+  @ApiQuery({ name: 'page', type: Number, required: false, default: 1 })
+  @ApiQuery({ name: 'search', type: String, required: false })
+  @ApiOkResponse({ type: PagingResultDto<RouteDto> })
+  findAll(
+    @Query('limit', ParseIntPipe) limit = 10,
+    @Query('page', ParseIntPipe) page = 1,
+    @Query('search') search?: string,
+  ) {
+    if (limit > MAX_PAGE_SIZE) {
+      throw new BadRequestException(`Limit cannot exceed ${MAX_PAGE_SIZE}`);
+    }
+    return this.routesService.findAll(limit, page, search);
+  }
+
+  @Get(':id')
+  @ApiParam({ name: 'id', type: String })
+  @ApiOkResponse({ type: RouteDto })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.routesService.findById(id);
+  }
+
+  @Patch(':id')
+  @ApiParam({ name: 'id', type: String })
+  @ApiBody({ type: UpdateRouteDto })
+  @ApiOkResponse({ type: RouteDto })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateRouteDto: UpdateRouteDto,
+  ) {
+    return this.routesService.update(id, updateRouteDto);
+  }
+}

--- a/src/routes/routes.module.ts
+++ b/src/routes/routes.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RoutesService } from './routes.service';
+import { RoutesController } from './routes.controller';
+import { RoutesRepository } from './routes.repository';
+
+@Module({
+  controllers: [RoutesController],
+  providers: [RoutesService, RoutesRepository],
+})
+export class RoutesModule {}

--- a/src/routes/routes.repository.ts
+++ b/src/routes/routes.repository.ts
@@ -1,0 +1,71 @@
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { CustomPrismaService } from 'nestjs-prisma';
+import { ExtendedPrismaClient } from 'prisma/prisma.extension';
+import { CreateRouteDto } from 'prisma/src/generated/dto/create-route.dto';
+import { UpdateRouteDto } from 'prisma/src/generated/dto/update-route.dto';
+import { RouteDto } from 'prisma/src/generated/dto/route.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { transformResponse } from 'lib/utils/transform';
+import { isNoChange } from 'lib/utils/isNoChange';
+
+@Injectable()
+export class RoutesRepository {
+  constructor(
+    @Inject('PrismaService')
+    private prismaService: CustomPrismaService<ExtendedPrismaClient>,
+  ) {}
+
+  async create(data: CreateRouteDto): Promise<RouteDto> {
+    const existing = await this.prismaService.client.route.findFirst({
+      where: { name: data.name },
+    });
+    if (existing) {
+      throw new BadRequestException(`Route with name ${data.name} already exists`);
+    }
+    const route = await this.prismaService.client.route.create({ data });
+    return transformResponse(RouteDto, route);
+  }
+
+  async findAll(limit = 10, page = 1, search?: string): Promise<PagingResultDto<RouteDto>> {
+    const [routes, meta] = await this.prismaService.client.route
+      .paginate({
+        where: {
+          deleted: false,
+          name: search ? { contains: search, mode: 'insensitive' } : undefined,
+        },
+      })
+      .withPages({ limit, page, includePageCount: true });
+
+    return {
+      data: routes.map((r: RouteDto) => transformResponse(RouteDto, r)),
+      meta,
+    };
+  }
+
+  async findById(routeId: string): Promise<RouteDto> {
+    const route = await this.prismaService.client.route.findUnique({
+      where: { routeId },
+    });
+    if (!route) {
+      throw new NotFoundException(`Route with ID ${routeId} not found`);
+    }
+    return transformResponse(RouteDto, route);
+  }
+
+  async update(routeId: string, data: UpdateRouteDto): Promise<RouteDto> {
+    const existing = await this.prismaService.client.route.findUnique({
+      where: { routeId },
+    });
+    if (!existing) {
+      throw new NotFoundException(`Route with ID ${routeId} not found`);
+    }
+    if (isNoChange<UpdateRouteDto>(data, existing)) {
+      throw new BadRequestException(`No changes detected for route ${routeId}`);
+    }
+    const route = await this.prismaService.client.route.update({
+      where: { routeId },
+      data,
+    });
+    return transformResponse(RouteDto, route);
+  }
+}

--- a/src/routes/routes.service.ts
+++ b/src/routes/routes.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { RoutesRepository } from './routes.repository';
+import { CreateRouteDto } from 'prisma/src/generated/dto/create-route.dto';
+import { UpdateRouteDto } from 'prisma/src/generated/dto/update-route.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { RouteDto } from 'prisma/src/generated/dto/route.dto';
+
+@Injectable()
+export class RoutesService {
+  constructor(private readonly routesRepository: RoutesRepository) {}
+
+  create(createRouteDto: CreateRouteDto): Promise<RouteDto> {
+    return this.routesRepository.create(createRouteDto);
+  }
+
+  findAll(limit = 10, page = 1, search?: string): Promise<PagingResultDto<RouteDto>> {
+    return this.routesRepository.findAll(limit, page, search);
+  }
+
+  findById(id: string): Promise<RouteDto> {
+    return this.routesRepository.findById(id);
+  }
+
+  update(id: string, updateRouteDto: UpdateRouteDto): Promise<RouteDto> {
+    return this.routesRepository.update(id, updateRouteDto);
+  }
+}


### PR DESCRIPTION
## Summary
- add modules for Address, Invoice and Route
- expose CRUD endpoints in controllers
- handle create, update, find and list in repositories/services
- register the new modules in `AppModule`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690b80f7cc832b8c929ebf21973bd3