### PR TITLE
Implement statistics endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AddressesModule } from './addresses/addresses.module';
 import { InvoicesModule } from './invoices/invoices.module';
 import { RoutesModule } from './routes/routes.module';
+import { StatisticsModule } from './statistics/statistics.module';
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { RoutesModule } from './routes/routes.module';
     AddressesModule,
     InvoicesModule,
     RoutesModule,
+    StatisticsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/statistics/dto/customer-business-sector.dto.ts
+++ b/src/statistics/dto/customer-business-sector.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { BusinessSector } from '@prisma/client';
+
+export class CustomerBusinessSectorDto {
+  @ApiProperty()
+  totalCustomers: number;
+
+  @ApiProperty({ type: 'object', additionalProperties: { type: 'number' } })
+  sectors: Record<BusinessSector, number>;
+}

--- a/src/statistics/dto/order-state-count.dto.ts
+++ b/src/statistics/dto/order-state-count.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { OrderState } from '@prisma/client';
+import { IsEnum, IsInt } from 'class-validator';
+
+export class OrderStateCountDto {
+  @ApiProperty({ enum: OrderState })
+  @IsEnum(OrderState)
+  orderState: OrderState;
+
+  @ApiProperty()
+  @IsInt()
+  _count: number;
+}

--- a/src/statistics/dto/quick-stats.dto.ts
+++ b/src/statistics/dto/quick-stats.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class QuickStatsDto {
+  @ApiProperty()
+  totalCustomers: number;
+
+  @ApiProperty()
+  totalOrders: number;
+
+  @ApiProperty()
+  totalEmployees: number;
+
+  @ApiProperty()
+  totalProducts: number;
+
+  @ApiProperty()
+  totalCategories: number;
+
+  @ApiProperty()
+  totalRoutes: number;
+
+  @ApiProperty()
+  totalInvoices: number;
+}

--- a/src/statistics/statistics.controller.spec.ts
+++ b/src/statistics/statistics.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StatisticsController } from './statistics.controller';
+import { StatisticsService } from './statistics.service';
+
+describe('StatisticsController', () => {
+  let controller: StatisticsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StatisticsController],
+      providers: [StatisticsService],
+    }).compile();
+
+    controller = module.get<StatisticsController>(StatisticsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/statistics/statistics.controller.ts
+++ b/src/statistics/statistics.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get, UseInterceptors, UseGuards } from '@nestjs/common';
+import { CacheInterceptor } from '@nestjs/cache-manager';
+import { StatisticsService } from './statistics.service';
+import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
+import {
+  ApiBearerAuth,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+} from '@nestjs/swagger';
+import { OrderStateCountDto } from './dto/order-state-count.dto';
+import { CustomerBusinessSectorDto } from './dto/customer-business-sector.dto';
+import { QuickStatsDto } from './dto/quick-stats.dto';
+
+@Controller('statistics')
+@UseInterceptors(CacheInterceptor)
+@ApiInternalServerErrorResponse({ description: 'Internal server error' })
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+export class StatisticsController {
+  constructor(private readonly statisticsService: StatisticsService) {}
+
+  @Get('orders/state')
+  @ApiOkResponse({ type: OrderStateCountDto, isArray: true })
+  getOrderStates() {
+    return this.statisticsService.getOrderStateCounts();
+  }
+
+  @Get('customers/business-sector')
+  @ApiOkResponse({ type: CustomerBusinessSectorDto })
+  getCustomerBusinessSectors() {
+    return this.statisticsService.getCustomerBusinessSectors();
+  }
+
+  @Get('quick')
+  @ApiOkResponse({ type: QuickStatsDto })
+  getQuickStats() {
+    return this.statisticsService.getQuickStats();
+  }
+}

--- a/src/statistics/statistics.module.ts
+++ b/src/statistics/statistics.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { StatisticsController } from './statistics.controller';
+import { StatisticsService } from './statistics.service';
+import { StatisticsRepository } from './statistics.repository';
+
+@Module({
+  controllers: [StatisticsController],
+  providers: [StatisticsService, StatisticsRepository],
+})
+export class StatisticsModule {}

--- a/src/statistics/statistics.repository.ts
+++ b/src/statistics/statistics.repository.ts
@@ -1,0 +1,78 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { CustomPrismaService } from 'nestjs-prisma';
+import { ExtendedPrismaClient } from 'prisma/prisma.extension';
+import { OrderState, BusinessSector } from '@prisma/client';
+import { OrderStateCountDto } from './dto/order-state-count.dto';
+import { CustomerBusinessSectorDto } from './dto/customer-business-sector.dto';
+import { QuickStatsDto } from './dto/quick-stats.dto';
+
+@Injectable()
+export class StatisticsRepository {
+  constructor(
+    @Inject('PrismaService')
+    private readonly prisma: CustomPrismaService<ExtendedPrismaClient>,
+  ) {}
+
+  async getOrderStateCounts(): Promise<OrderStateCountDto[]> {
+    const grouped = await this.prisma.client.order.groupBy({
+      by: ['orderState'],
+      _count: true,
+    });
+
+    return grouped.map((g) => ({
+      orderState: g.orderState as OrderState,
+      _count: g._count,
+    }));
+  }
+
+  async getCustomerBusinessSectors(): Promise<CustomerBusinessSectorDto> {
+    const grouped = await this.prisma.client.customer.groupBy({
+      by: ['businessSector'],
+      _count: true,
+    });
+
+    const sectors = grouped.reduce(
+      (acc, cur) => {
+        if (cur.businessSector) {
+          acc[cur.businessSector as BusinessSector] = cur._count;
+        }
+        return acc;
+      },
+      {} as Record<BusinessSector, number>,
+    );
+
+    const totalCustomers = await this.prisma.client.customer.count();
+
+    return { totalCustomers, sectors };
+  }
+
+  async getQuickStats(): Promise<QuickStatsDto> {
+    const [
+      totalCustomers,
+      totalOrders,
+      totalEmployees,
+      totalProducts,
+      totalCategories,
+      totalRoutes,
+      totalInvoices,
+    ] = await this.prisma.client.$transaction([
+      this.prisma.client.customer.count(),
+      this.prisma.client.order.count(),
+      this.prisma.client.employees.count(),
+      this.prisma.client.product.count(),
+      this.prisma.client.category.count(),
+      this.prisma.client.route.count(),
+      this.prisma.client.invoice.count(),
+    ]);
+
+    return {
+      totalCustomers,
+      totalOrders,
+      totalEmployees,
+      totalProducts,
+      totalCategories,
+      totalRoutes,
+      totalInvoices,
+    };
+  }
+}

--- a/src/statistics/statistics.service.spec.ts
+++ b/src/statistics/statistics.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StatisticsService } from './statistics.service';
+
+describe('StatisticsService', () => {
+  let service: StatisticsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [StatisticsService],
+    }).compile();
+
+    service = module.get<StatisticsService>(StatisticsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/statistics/statistics.service.ts
+++ b/src/statistics/statistics.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { StatisticsRepository } from './statistics.repository';
+
+@Injectable()
+export class StatisticsService {
+  constructor(private readonly statisticsRepository: StatisticsRepository) {}
+
+  getOrderStateCounts() {
+    return this.statisticsRepository.getOrderStateCounts();
+  }
+
+  getCustomerBusinessSectors() {
+    return this.statisticsRepository.getCustomerBusinessSectors();
+  }
+
+  getQuickStats() {
+    return this.statisticsRepository.getQuickStats();
+  }
+}


### PR DESCRIPTION
## Summary
- add statistics module to expose aggregated data
- provide DTOs for customer sector distribution, order state counts and quick stats
- include minimal tests for controller and service
- register statistics module in the app

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869643df834832bb1ba52bf0674479e