### PR TITLE
Add statistics endpoints

### DIFF
--- a/src/statistics/dto/average-order-value-stats.dto.ts
+++ b/src/statistics/dto/average-order-value-stats.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNumber, IsOptional } from 'class-validator';
+
+export class AverageOrderValueStatsDto {
+  @ApiProperty()
+  @IsInt()
+  currentMonthAIV: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsInt()
+  lastMonthAIV: number | null;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  percentageChange: number | null;
+}

--- a/src/statistics/dto/customer-stats.dto.ts
+++ b/src/statistics/dto/customer-stats.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNumber, IsOptional } from 'class-validator';
+
+export class CustomerStatsDto {
+  @ApiProperty()
+  @IsInt()
+  currentMonthSignUps: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  percentageChange: number | null;
+}

--- a/src/statistics/dto/revenue-stats.dto.ts
+++ b/src/statistics/dto/revenue-stats.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNumber, IsOptional } from 'class-validator';
+
+export class RevenueStatsDto {
+  @ApiProperty()
+  @IsInt()
+  currentMonthRevenue: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  percentageChange: number | null;
+}

--- a/src/statistics/dto/sales-stats.dto.ts
+++ b/src/statistics/dto/sales-stats.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNumber, IsOptional } from 'class-validator';
+
+export class SalesStatsDto {
+  @ApiProperty()
+  @IsInt()
+  currentMonthSales: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  percentageChange: number | null;
+}

--- a/src/statistics/statistics.controller.ts
+++ b/src/statistics/statistics.controller.ts
@@ -10,6 +10,10 @@ import {
 import { OrderStateCountDto } from './dto/order-state-count.dto';
 import { CustomerBusinessSectorDto } from './dto/customer-business-sector.dto';
 import { QuickStatsDto } from './dto/quick-stats.dto';
+import { RevenueStatsDto } from './dto/revenue-stats.dto';
+import { SalesStatsDto } from './dto/sales-stats.dto';
+import { AverageOrderValueStatsDto } from './dto/average-order-value-stats.dto';
+import { CustomerStatsDto } from './dto/customer-stats.dto';
 
 @Controller('statistics')
 @UseInterceptors(CacheInterceptor)
@@ -35,5 +39,29 @@ export class StatisticsController {
   @ApiOkResponse({ type: QuickStatsDto })
   getQuickStats() {
     return this.statisticsService.getQuickStats();
+  }
+
+  @Get('revenue')
+  @ApiOkResponse({ type: RevenueStatsDto })
+  getRevenueStats() {
+    return this.statisticsService.getRevenueStats();
+  }
+
+  @Get('sales')
+  @ApiOkResponse({ type: SalesStatsDto })
+  getSalesStats() {
+    return this.statisticsService.getSalesStats();
+  }
+
+  @Get('average-order-value')
+  @ApiOkResponse({ type: AverageOrderValueStatsDto })
+  getAverageOrderValueStats() {
+    return this.statisticsService.getAverageOrderValueStats();
+  }
+
+  @Get('customers/monthly-signups')
+  @ApiOkResponse({ type: CustomerStatsDto })
+  getCustomerStats() {
+    return this.statisticsService.getCustomerStats();
   }
 }

--- a/src/statistics/statistics.repository.ts
+++ b/src/statistics/statistics.repository.ts
@@ -5,6 +5,10 @@ import { OrderState, BusinessSector } from '@prisma/client';
 import { OrderStateCountDto } from './dto/order-state-count.dto';
 import { CustomerBusinessSectorDto } from './dto/customer-business-sector.dto';
 import { QuickStatsDto } from './dto/quick-stats.dto';
+import { RevenueStatsDto } from './dto/revenue-stats.dto';
+import { SalesStatsDto } from './dto/sales-stats.dto';
+import { AverageOrderValueStatsDto } from './dto/average-order-value-stats.dto';
+import { CustomerStatsDto } from './dto/customer-stats.dto';
 
 @Injectable()
 export class StatisticsRepository {
@@ -74,5 +78,114 @@ export class StatisticsRepository {
       totalRoutes,
       totalInvoices,
     };
+  }
+
+  private getMonthDateRange(date: Date) {
+    const start = new Date(date.getFullYear(), date.getMonth(), 1);
+    const end = new Date(date.getFullYear(), date.getMonth() + 1, 1);
+    return { start, end };
+  }
+
+  async getRevenueStats(): Promise<RevenueStatsDto> {
+    const { start: currentStart, end: currentEnd } = this.getMonthDateRange(new Date());
+    const { start: lastStart, end: lastEnd } = this.getMonthDateRange(
+      new Date(new Date().getFullYear(), new Date().getMonth() - 1, 1),
+    );
+
+    const [current, last] = await this.prisma.client.$transaction([
+      this.prisma.client.invoice.aggregate({
+        _sum: { invoiceAmount: true },
+        where: { paymentDate: { gte: currentStart, lt: currentEnd } },
+      }),
+      this.prisma.client.invoice.aggregate({
+        _sum: { invoiceAmount: true },
+        where: { paymentDate: { gte: lastStart, lt: lastEnd } },
+      }),
+    ]);
+
+    const currentRevenue = current._sum.invoiceAmount || 0;
+    const lastRevenue = last._sum.invoiceAmount || 0;
+    const percentageChange =
+      lastRevenue !== 0
+        ? Number(((currentRevenue - lastRevenue) / lastRevenue) * 100)
+        : null;
+
+    return { currentMonthRevenue: currentRevenue, percentageChange };
+  }
+
+  async getSalesStats(): Promise<SalesStatsDto> {
+    const { start: currentStart, end: currentEnd } = this.getMonthDateRange(new Date());
+    const { start: lastStart, end: lastEnd } = this.getMonthDateRange(
+      new Date(new Date().getFullYear(), new Date().getMonth() - 1, 1),
+    );
+
+    const [current, last] = await this.prisma.client.$transaction([
+      this.prisma.client.order.count({
+        where: { orderDate: { gte: currentStart, lt: currentEnd } },
+      }),
+      this.prisma.client.order.count({
+        where: { orderDate: { gte: lastStart, lt: lastEnd } },
+      }),
+    ]);
+
+    const percentageChange =
+      last !== 0 ? Number(((current - last) / last) * 100) : null;
+
+    return { currentMonthSales: current, percentageChange };
+  }
+
+  async getAverageOrderValueStats(): Promise<AverageOrderValueStatsDto> {
+    const { start: currentStart, end: currentEnd } = this.getMonthDateRange(new Date());
+    const { start: lastStart, end: lastEnd } = this.getMonthDateRange(
+      new Date(new Date().getFullYear(), new Date().getMonth() - 1, 1),
+    );
+
+    const [current, last] = await this.prisma.client.$transaction([
+      this.prisma.client.invoice.aggregate({
+        _avg: { invoiceAmount: true },
+        where: { paymentDate: { gte: currentStart, lt: currentEnd } },
+      }),
+      this.prisma.client.invoice.aggregate({
+        _avg: { invoiceAmount: true },
+        where: { paymentDate: { gte: lastStart, lt: lastEnd } },
+      }),
+    ]);
+
+    const currentAvg = Math.round(current._avg.invoiceAmount ?? 0);
+    const lastAvg = last._avg.invoiceAmount
+      ? Math.round(last._avg.invoiceAmount)
+      : null;
+
+    const percentageChange =
+      lastAvg && lastAvg !== 0
+        ? Number(((currentAvg - lastAvg) / lastAvg) * 100)
+        : null;
+
+    return {
+      currentMonthAIV: currentAvg,
+      lastMonthAIV: lastAvg,
+      percentageChange,
+    };
+  }
+
+  async getCustomerStats(): Promise<CustomerStatsDto> {
+    const { start: currentStart, end: currentEnd } = this.getMonthDateRange(new Date());
+    const { start: lastStart, end: lastEnd } = this.getMonthDateRange(
+      new Date(new Date().getFullYear(), new Date().getMonth() - 1, 1),
+    );
+
+    const [current, last] = await this.prisma.client.$transaction([
+      this.prisma.client.customer.count({
+        where: { signedUp: { gte: currentStart, lt: currentEnd } },
+      }),
+      this.prisma.client.customer.count({
+        where: { signedUp: { gte: lastStart, lt: lastEnd } },
+      }),
+    ]);
+
+    const percentageChange =
+      last !== 0 ? Number(((current - last) / last) * 100) : null;
+
+    return { currentMonthSignUps: current, percentageChange };
   }
 }

--- a/src/statistics/statistics.service.ts
+++ b/src/statistics/statistics.service.ts
@@ -16,4 +16,20 @@ export class StatisticsService {
   getQuickStats() {
     return this.statisticsRepository.getQuickStats();
   }
+
+  getRevenueStats() {
+    return this.statisticsRepository.getRevenueStats();
+  }
+
+  getSalesStats() {
+    return this.statisticsRepository.getSalesStats();
+  }
+
+  getAverageOrderValueStats() {
+    return this.statisticsRepository.getAverageOrderValueStats();
+  }
+
+  getCustomerStats() {
+    return this.statisticsRepository.getCustomerStats();
+  }
 }


### PR DESCRIPTION
## Summary
- add DTOs for revenue, sales, AOV and customer stats
- extend `StatisticsRepository` with methods to compute new stats
- expose new service methods
- expose new endpoints in `StatisticsController`

## Testing
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696d1941a4832bba5ebb24012190fc