### PR TITLE
Add site config resource

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,7 @@ import { AddressesModule } from './addresses/addresses.module';
 import { InvoicesModule } from './invoices/invoices.module';
 import { RoutesModule } from './routes/routes.module';
 import { StatisticsModule } from './statistics/statistics.module';
+import { SiteConfigModule } from './site-config/site-config.module';
 
 @Module({
   imports: [
@@ -74,6 +75,7 @@ import { StatisticsModule } from './statistics/statistics.module';
     AddressesModule,
     InvoicesModule,
     RoutesModule,
+    SiteConfigModule,
     StatisticsModule,
   ],
   controllers: [AppController],

--- a/src/site-config/site-config.controller.ts
+++ b/src/site-config/site-config.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Query,
+  ParseUUIDPipe,
+  ParseIntPipe,
+  UseInterceptors,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { SiteConfigService } from './site-config.service';
+import { CacheInterceptor } from '@nestjs/cache-manager';
+import { Ressources } from '@prisma/client';
+import { Resource } from 'lib/decorators/ressource-decorator';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
+import { PermissionsGuard } from 'src/auth/guards/RBACGuard';
+import { CreateSiteConfigDto } from 'prisma/src/generated/dto/create-siteConfig.dto';
+import { UpdateSiteConfigDto } from 'prisma/src/generated/dto/update-siteConfig.dto';
+import { SiteConfigDto } from 'prisma/src/generated/dto/siteConfig.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { MAX_PAGE_SIZE } from 'lib/constants';
+
+@Controller('site-config')
+@UseInterceptors(CacheInterceptor)
+@Resource(Ressources.SITE_CONFIG)
+@ApiInternalServerErrorResponse({ description: 'Internal server error' })
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@ApiForbiddenResponse({
+  description:
+    'Role does not have the permissions to perform this action on the requested ressource',
+})
+export class SiteConfigController {
+  constructor(private readonly siteConfigService: SiteConfigService) {}
+
+  @Post()
+  @ApiBody({ type: CreateSiteConfigDto })
+  @ApiOkResponse({ type: SiteConfigDto })
+  create(@Body() createDto: CreateSiteConfigDto) {
+    return this.siteConfigService.create(createDto);
+  }
+
+  @Get()
+  @ApiQuery({ name: 'limit', type: Number, required: false, default: 10, maximum: MAX_PAGE_SIZE })
+  @ApiQuery({ name: 'page', type: Number, required: false, default: 1 })
+  @ApiOkResponse({ type: PagingResultDto<SiteConfigDto> })
+  findAll(
+    @Query('limit', ParseIntPipe) limit = 10,
+    @Query('page', ParseIntPipe) page = 1,
+  ) {
+    if (limit > MAX_PAGE_SIZE) {
+      throw new BadRequestException(`Limit cannot exceed ${MAX_PAGE_SIZE}`);
+    }
+    return this.siteConfigService.findAll(limit, page);
+  }
+
+  @Get(':id')
+  @ApiParam({ name: 'id', type: String })
+  @ApiOkResponse({ type: SiteConfigDto })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.siteConfigService.findById(id);
+  }
+
+  @Patch(':id')
+  @ApiParam({ name: 'id', type: String })
+  @ApiBody({ type: UpdateSiteConfigDto })
+  @ApiOkResponse({ type: SiteConfigDto })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateDto: UpdateSiteConfigDto,
+  ) {
+    return this.siteConfigService.update(id, updateDto);
+  }
+}

--- a/src/site-config/site-config.module.ts
+++ b/src/site-config/site-config.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SiteConfigService } from './site-config.service';
+import { SiteConfigController } from './site-config.controller';
+import { SiteConfigRepository } from './site-config.repository';
+
+@Module({
+  controllers: [SiteConfigController],
+  providers: [SiteConfigService, SiteConfigRepository],
+})
+export class SiteConfigModule {}

--- a/src/site-config/site-config.repository.ts
+++ b/src/site-config/site-config.repository.ts
@@ -1,0 +1,60 @@
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { CustomPrismaService } from 'nestjs-prisma';
+import { ExtendedPrismaClient } from 'prisma/prisma.extension';
+import { CreateSiteConfigDto } from 'prisma/src/generated/dto/create-siteConfig.dto';
+import { SiteConfigDto } from 'prisma/src/generated/dto/siteConfig.dto';
+import { UpdateSiteConfigDto } from 'prisma/src/generated/dto/update-siteConfig.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { transformResponse } from 'lib/utils/transform';
+import { isNoChange } from 'lib/utils/isNoChange';
+
+@Injectable()
+export class SiteConfigRepository {
+  constructor(
+    @Inject('PrismaService')
+    private readonly prismaService: CustomPrismaService<ExtendedPrismaClient>,
+  ) {}
+
+  async create(data: CreateSiteConfigDto): Promise<SiteConfigDto> {
+    const siteConfig = await this.prismaService.client.siteConfig.create({ data });
+    return transformResponse(SiteConfigDto, siteConfig);
+  }
+
+  async findAll(limit = 10, page = 1): Promise<PagingResultDto<SiteConfigDto>> {
+    const [configs, meta] = await this.prismaService.client.siteConfig
+      .paginate({ where: { deleted: false } })
+      .withPages({ limit, page, includePageCount: true });
+
+    return {
+      data: configs.map((c: SiteConfigDto) => transformResponse(SiteConfigDto, c)),
+      meta,
+    };
+  }
+
+  async findById(siteConfigId: string): Promise<SiteConfigDto> {
+    const config = await this.prismaService.client.siteConfig.findUnique({
+      where: { siteConfigId },
+    });
+    if (!config) {
+      throw new NotFoundException(`SiteConfig with ID ${siteConfigId} not found`);
+    }
+    return transformResponse(SiteConfigDto, config);
+  }
+
+  async update(siteConfigId: string, data: UpdateSiteConfigDto): Promise<SiteConfigDto> {
+    const existing = await this.prismaService.client.siteConfig.findUnique({
+      where: { siteConfigId },
+    });
+    if (!existing) {
+      throw new NotFoundException(`SiteConfig with ID ${siteConfigId} not found`);
+    }
+    if (isNoChange<UpdateSiteConfigDto>(data, existing)) {
+      throw new BadRequestException(`No changes detected for site config ${siteConfigId}`);
+    }
+    const config = await this.prismaService.client.siteConfig.update({
+      where: { siteConfigId },
+      data,
+    });
+    return transformResponse(SiteConfigDto, config);
+  }
+}

--- a/src/site-config/site-config.service.ts
+++ b/src/site-config/site-config.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { SiteConfigRepository } from './site-config.repository';
+import { CreateSiteConfigDto } from 'prisma/src/generated/dto/create-siteConfig.dto';
+import { UpdateSiteConfigDto } from 'prisma/src/generated/dto/update-siteConfig.dto';
+import { SiteConfigDto } from 'prisma/src/generated/dto/siteConfig.dto';
+import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+
+@Injectable()
+export class SiteConfigService {
+  constructor(private readonly siteConfigRepository: SiteConfigRepository) {}
+
+  create(createDto: CreateSiteConfigDto): Promise<SiteConfigDto> {
+    return this.siteConfigRepository.create(createDto);
+  }
+
+  findAll(limit = 10, page = 1): Promise<PagingResultDto<SiteConfigDto>> {
+    return this.siteConfigRepository.findAll(limit, page);
+  }
+
+  findById(id: string): Promise<SiteConfigDto> {
+    return this.siteConfigRepository.findById(id);
+  }
+
+  update(id: string, updateDto: UpdateSiteConfigDto): Promise<SiteConfigDto> {
+    return this.siteConfigRepository.update(id, updateDto);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `site-config` REST resource with controller, service, and repository
- wire new `SiteConfigModule` into application module

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a240fc36c832bb050309b7d26845a