### PR TITLE
Fix docker build dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,14 @@ COPY prisma ./prisma/
 RUN npm install -g pnpm
 
 # Install app dependencies
-RUN pnpm install
+RUN pnpm install --frozen-lockfile --prod=false
 
 COPY . .
 
 RUN pnpm run build
 
 FROM node:latest
+WORKDIR /app
 
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./


### PR DESCRIPTION
## Summary
- ensure dev dependencies are installed in Docker
- set WORKDIR for final Docker image

## Testing
- `pnpm run lint` *(fails: unsafe member access)*
- `pnpm run test` *(fails to compile prisma models)*

------
https://chatgpt.com/codex/tasks/task_e_6871543ecbc0832b833a49beff986241