### PR TITLE
Add multiple action support to permission creation

### DIFF
--- a/src/permissions/dto/create-permissions.dto.ts
+++ b/src/permissions/dto/create-permissions.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Actions, Ressources } from '@prisma/client';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsBoolean,
+  IsOptional,
+  IsString,
+  Matches,
+} from 'class-validator';
+
+export class CreatePermissionsDto {
+  @ApiProperty({
+    type: String,
+    description: 'Role to which permissions will be assigned',
+    example: 'EMPLOYEE',
+  })
+  @Matches(/^[A-Z_]+$/, {
+    message:
+      'Role must be in uppercase and can only contain letters and underscores',
+  })
+  @IsString()
+  role: string;
+
+  @ApiProperty({
+    enum: Ressources,
+    description: 'Resource for which permissions are granted',
+    example: 'CUSTOMER',
+  })
+  @Matches(/^[A-Z_]+$/, {
+    message:
+      'Resource must be in uppercase and can only contain letters and underscores',
+  })
+  resource: Ressources;
+
+  @ApiProperty({
+    enum: Actions,
+    isArray: true,
+    description: 'Actions to grant for the resource',
+    example: [Actions.READ, Actions.CREATE],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  actions: Actions[];
+
+  @ApiProperty({
+    type: Boolean,
+    description: 'Whether the permission is allowed or denied',
+    example: true,
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  allowed?: boolean;
+}

--- a/src/permissions/permissions.controller.ts
+++ b/src/permissions/permissions.controller.ts
@@ -29,8 +29,9 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
 import { PermissionsGuard } from 'src/auth/guards/RBACGuard';
-import { CreatePermissionDto } from 'prisma/src/generated/dto/create-permission.dto';
+import { CreatePermissionsDto } from './dto/create-permissions.dto';
 import { UpdatePermissionDto } from 'prisma/src/generated/dto/update-permission.dto';
+import { PermissionDto } from 'prisma/src/generated/dto/permission.dto';
 import { MAX_PAGE_SIZE } from 'lib/constants';
 import { PermissionPagingResultDto } from './dto/permissions-paging';
 
@@ -51,8 +52,8 @@ export class PermissionsController {
 
   @Post()
   @ApiBody({
-    type: CreatePermissionDto,
-    description: 'Create a new permission',
+    type: CreatePermissionsDto,
+    description: 'Create one or multiple permissions',
   })
   @ApiForbiddenResponse({
     description: 'You do not have permission to create a permission',
@@ -61,11 +62,12 @@ export class PermissionsController {
     description: 'Permission already exists',
   })
   @ApiOkResponse({
-    description: 'Permission created successfully',
-    type: CreatePermissionDto,
+    description: 'Permissions created successfully',
+    type: PermissionDto,
+    isArray: true,
   })
-  create(@Body() createPermissionDto: CreatePermissionDto) {
-    return this.permissionsService.create(createPermissionDto);
+  create(@Body() createPermissionsDto: CreatePermissionsDto) {
+    return this.permissionsService.create(createPermissionsDto);
   }
 
   @Get()

--- a/src/permissions/permissions.repository.ts
+++ b/src/permissions/permissions.repository.ts
@@ -4,7 +4,7 @@ import { ExtendedPrismaClient } from 'prisma/prisma.extension';
 import { PermissionPagingResultDto } from './dto/permissions-paging';
 import { transformResponse } from 'lib/utils/transform';
 import { PermissionDto } from 'prisma/src/generated/dto/permission.dto';
-import { CreatePermissionDto } from 'prisma/src/generated/dto/create-permission.dto';
+import { CreatePermissionsDto } from './dto/create-permissions.dto';
 import { UpdatePermissionDto } from 'prisma/src/generated/dto/update-permission.dto';
 import { CustomerDto } from 'src/customers/dto/customer.dto';
 import { Actions, Ressources } from '@prisma/client';
@@ -54,56 +54,57 @@ export class PermissionsRepository {
     return transformResponse(PermissionDto, permission);
   }
 
-  async create(permissionData: CreatePermissionDto): Promise<PermissionDto> {
-    // check if the permissionData.resource is in Ressources enum
 
-    if (!Object.values(Actions).includes(permissionData.action)) {
-      throw new BadRequestException(
-        `Invalid action type: ${permissionData.action}. Must be one of ${Object.values(Actions).join(', ')}`,
-      );
-    }
+  async create(dto: CreatePermissionsDto): Promise<PermissionDto[]> {
+    const results: PermissionDto[] = [];
+    for (const action of dto.actions) {
+      if (!Object.values(Actions).includes(action)) {
+        throw new BadRequestException(
+          `Invalid action type: ${action}. Must be one of ${Object.values(Actions).join(', ')}`,
+        );
+      }
 
-    if (!Object.values(Ressources).includes(permissionData.resource)) {
-      throw new BadRequestException(
-        `Invalid resource type: ${permissionData.resource}. Must be one of ${Object.values(Ressources).join(', ')}`,
-      );
-    }
+      if (!Object.values(Ressources).includes(dto.resource)) {
+        throw new BadRequestException(
+          `Invalid resource type: ${dto.resource}. Must be one of ${Object.values(Ressources).join(', ')}`,
+        );
+      }
 
-    // check if the role exists
-    const roleExists = await this.rolesRepository.findByName(
-      permissionData.role,
-    );
+      const roleExists = await this.rolesRepository.findByName(dto.role);
 
-    if (!roleExists) {
-      throw new BadRequestException(
-        `Role with name ${permissionData.role} does not exist`,
-      );
-    }
+      if (!roleExists) {
+        throw new BadRequestException(
+          `Role with name ${dto.role} does not exist`,
+        );
+      }
 
-    // check if the permission already exists
-    const existingPermission =
-      await this.prismaService.client.permission.findFirst({
+      const existingPermission = await this.prismaService.client.permission.findFirst({
         where: {
-          action: permissionData.action,
-          resource: permissionData.resource,
-          role: permissionData.role,
+          action,
+          resource: dto.resource,
+          role: dto.role,
         },
       });
 
-    if (existingPermission) {
-      throw new BadRequestException(
-        `Permission with action ${permissionData.action}, resource ${permissionData.resource}, and role ${permissionData.role} already exists`,
-      );
+      if (existingPermission) {
+        throw new BadRequestException(
+          `Permission with action ${action}, resource ${dto.resource}, and role ${dto.role} already exists`,
+        );
+      }
+
+      const createdPermission = await this.prismaService.client.permission.create({
+        data: {
+          role: dto.role,
+          resource: dto.resource,
+          action,
+          allowed: dto.allowed,
+        },
+      });
+      results.push(transformResponse(PermissionDto, createdPermission));
     }
 
-    const createdPermission = await this.prismaService.client.permission.create(
-      {
-        data: permissionData,
-      },
-    );
-    return transformResponse(PermissionDto, createdPermission);
+    return results;
   }
-
   async update(
     id: string,
     permissionData: Partial<UpdatePermissionDto>,

--- a/src/permissions/permissions.service.ts
+++ b/src/permissions/permissions.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { CreatePermissionDto } from 'prisma/src/generated/dto/create-permission.dto';
+import { CreatePermissionsDto } from './dto/create-permissions.dto';
 import { UpdatePermissionDto } from 'prisma/src/generated/dto/update-permission.dto';
 import { PermissionsRepository } from './permissions.repository';
 
@@ -7,8 +7,8 @@ import { PermissionsRepository } from './permissions.repository';
 export class PermissionsService {
   constructor(private permissionsRepository: PermissionsRepository) {}
 
-  create(createPermissionDto: CreatePermissionDto) {
-    return this.permissionsRepository.create(createPermissionDto);
+  create(createPermissionsDto: CreatePermissionsDto) {
+    return this.permissionsRepository.create(createPermissionsDto);
   }
 
   findAll(limit: number = 10, page: number = 1, role?: string) {


### PR DESCRIPTION
## Summary
- replace single-action create with array-based DTO
- allow POST /permissions to accept multiple actions
- remove bulk endpoint and createMany logic

## Testing
- `pnpm test` *(fails: Jest cannot find Prisma exports and modules)*

------
https://chatgpt.com/codex/tasks/task_e_6873673888f0832bada9a5275391cd79