### PR TITLE
Implement cache invalidation for POST and PATCH

### DIFF
--- a/lib/interceptors/cache-invalidation.interceptor.ts
+++ b/lib/interceptors/cache-invalidation.interceptor.ts
@@ -1,0 +1,43 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import type { Cache } from 'cache-manager';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+@Injectable()
+export class CacheInvalidationInterceptor implements NestInterceptor {
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+
+  async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
+    const request = context.switchToHttp().getRequest();
+    const method = request.method;
+
+    if (!['POST', 'PATCH'].includes(method)) {
+      return next.handle();
+    }
+
+    const url: string = request.baseUrl || request.url || '';
+    const resource = url.split('/').filter(Boolean)[0];
+
+    return next.handle().pipe(
+      tap(async () => {
+        try {
+          const store: any = (this.cacheManager as any).store;
+          const keys: string[] = (await store.keys()) as string[];
+          const matched = keys.filter((key) =>
+            key.includes(`/${resource}`),
+          );
+          await Promise.all(matched.map((key) => this.cacheManager.del(key)));
+        } catch (err) {
+          console.error('Cache invalidation failed', err);
+        }
+      }),
+    );
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { CustomPrismaModule } from 'nestjs-prisma';
@@ -11,6 +12,7 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { CacheableMemory } from 'cacheable';
 import { createKeyv } from '@keyv/redis';
 import { Keyv } from 'keyv';
+import { CacheInvalidationInterceptor } from '../lib/interceptors/cache-invalidation.interceptor';
 import { RolesModule } from './roles/roles.module';
 import { PermissionsModule } from './permissions/permissions.module';
 import { EmployeesModule } from './employees/employees.module';
@@ -79,6 +81,12 @@ import { SiteConfigModule } from './site-config/site-config.module';
     StatisticsModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: CacheInvalidationInterceptor,
+    },
+  ],
 })
 export class AppModule {}


### PR DESCRIPTION
## Summary
- add `CacheInvalidationInterceptor` to remove cached data for a resource after POST or PATCH requests
- register the interceptor globally in `AppModule`

## Testing
- `pnpm run lint` *(fails: 526 problems)*
- `pnpm test` *(fails to run test suites)*
- `pnpm build` *(fails: missing Prisma client exports)*

------
https://chatgpt.com/codex/tasks/task_e_68775a241c90832bb199142547f89f79