### PR TITLE
Handle Minio unavailability on product images

### DIFF
--- a/src/file-repository/file-repository.service.ts
+++ b/src/file-repository/file-repository.service.ts
@@ -13,12 +13,17 @@ export class FileRepositoryService {
   }
 
   async getFile(filename: string) {
-    return await this.minioService.presignedUrl(
-      'GET',
-      this._bucketName,
-      filename,
-      24 * 60 * 60, // 1 day in seconds
-    );
+    try {
+      return await this.minioService.presignedUrl(
+        'GET',
+        this._bucketName,
+        filename,
+        24 * 60 * 60, // 1 day in seconds
+      );
+    } catch (error) {
+      console.error('Could not generate minio URL', error);
+      return '';
+    }
   }
 
   uploadFile(file: Express.Multer.File): Promise<string> {


### PR DESCRIPTION
## Summary
- handle errors when generating Minio URLs in `FileRepositoryService`

## Testing
- `pnpm install`
- `pnpm test` *(fails: Cannot find module `.prisma/client/default` and others)*
- `pnpm exec eslint src/file-repository/file-repository.service.ts --fix`

------
https://chatgpt.com/codex/tasks/task_e_6877fc417468832bb5bf499ba534def2