### PR TITLE
Add product history service using event emitter

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { InvoicesModule } from './invoices/invoices.module';
 import { RoutesModule } from './routes/routes.module';
 import { StatisticsModule } from './statistics/statistics.module';
 import { SiteConfigModule } from './site-config/site-config.module';
+import { ProductHistoryModule } from './product-history/product-history.module';
 
 @Module({
   imports: [
@@ -78,6 +79,7 @@ import { SiteConfigModule } from './site-config/site-config.module';
     RoutesModule,
     SiteConfigModule,
     StatisticsModule,
+    ProductHistoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/event-emitter/interface/event-types.interface.ts
+++ b/src/event-emitter/interface/event-types.interface.ts
@@ -27,4 +27,22 @@ export interface EventPayloads {
     resource: string;
     actions: string[];
   };
+  'product.updated': {
+    productId: string;
+    name: string;
+    price: number;
+    description: string;
+    stock: number;
+    imagePath: string | null;
+    categoryId: string;
+  };
+  'product.created': {
+    productId: string;
+    name: string;
+    price: number;
+    description: string;
+    stock: number;
+    imagePath: string | null;
+    categoryId: string;
+  };
 }

--- a/src/product-history/product-history.module.ts
+++ b/src/product-history/product-history.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProductHistoryService } from './product-history.service';
+import { ProductHistoryRepository } from './product-history.repository';
+import { TypedEventEmitterModule } from 'src/event-emitter/event-emitter.module';
+
+@Module({
+  imports: [TypedEventEmitterModule],
+  providers: [ProductHistoryService, ProductHistoryRepository],
+})
+export class ProductHistoryModule {}

--- a/src/product-history/product-history.repository.ts
+++ b/src/product-history/product-history.repository.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { CustomPrismaService } from 'nestjs-prisma';
+import { ExtendedPrismaClient } from 'prisma/prisma.extension';
+import { EventPayloads } from 'src/event-emitter/interface/event-types.interface';
+
+@Injectable()
+export class ProductHistoryRepository {
+  constructor(
+    @Inject('PrismaService')
+    private readonly prisma: CustomPrismaService<ExtendedPrismaClient>,
+  ) {}
+
+  async create(data: EventPayloads['product.updated']) {
+    await this.prisma.client.productHistory.create({
+      data,
+    });
+  }
+}

--- a/src/product-history/product-history.service.ts
+++ b/src/product-history/product-history.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { ProductHistoryRepository } from './product-history.repository';
+import { EventPayloads } from 'src/event-emitter/interface/event-types.interface';
+
+@Injectable()
+export class ProductHistoryService {
+  constructor(private readonly historyRepository: ProductHistoryRepository) {}
+
+  @OnEvent('product.updated')
+  async handleProductUpdated(event: EventPayloads['product.updated']) {
+    await this.historyRepository.create(event);
+  }
+}

--- a/src/products/products.module.ts
+++ b/src/products/products.module.ts
@@ -3,9 +3,10 @@ import { ProductsService } from './products.service';
 import { ProductsController } from './products.controller';
 import { ProductsRepository } from './products.repository';
 import { FileRepositoryModule } from 'src/file-repository/file-repository.module';
+import { TypedEventEmitterModule } from 'src/event-emitter/event-emitter.module';
 
 @Module({
-  imports: [FileRepositoryModule],
+  imports: [FileRepositoryModule, TypedEventEmitterModule],
   controllers: [ProductsController],
   providers: [ProductsService, ProductsRepository],
   exports: [ProductsService, ProductsRepository],

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -5,12 +5,14 @@ import { UpdateProductDto } from 'src/products/dto/update-product.dto';
 import { ProductsRepository } from './products.repository';
 import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
 import { ProductDto } from './dto/product.dto';
+import { TypedEventEmitter } from 'src/event-emitter/typed-event-emitter.class';
 
 @Injectable()
 export class ProductsService {
   constructor(
     private readonly fileService: FileRepositoryService,
     private readonly productRepository: ProductsRepository,
+    private readonly eventEmitter: TypedEventEmitter,
   ) {}
   // products.service.ts
   async create(createProductDto: CreateProductDto, file: Express.Multer.File) {
@@ -23,7 +25,22 @@ export class ProductsService {
       console.log('Image filename:', imageFilename);
     }
 
-    return this.productRepository.create(createProductDto, imageFilename);
+    const product = await this.productRepository.create(
+      createProductDto,
+      imageFilename,
+    );
+
+    this.eventEmitter.emit('product.created', {
+      productId: product.productId,
+      name: product.name,
+      price: product.price,
+      description: product.description,
+      stock: product.stock,
+      imagePath: product.imagePath ?? null,
+      categoryId: product.categoryId,
+    });
+
+    return product;
   }
 
   async findAll(
@@ -79,13 +96,31 @@ export class ProductsService {
   ) {
     let imageFilename: string | undefined;
 
+    const originalProduct = await this.productRepository.findById(id);
+
     if (file) {
       const uploadResult = await this.fileService.uploadFile(file);
       console.log('File uploaded successfully:', uploadResult);
       imageFilename = uploadResult;
     }
 
-    return this.productRepository.update(id, updateProductDto, imageFilename);
+    const product = await this.productRepository.update(
+      id,
+      updateProductDto,
+      imageFilename,
+    );
+
+    this.eventEmitter.emit('product.updated', {
+      productId: originalProduct.productId,
+      name: originalProduct.name,
+      price: originalProduct.price,
+      description: originalProduct.description,
+      stock: originalProduct.stock,
+      imagePath: originalProduct.imagePath ?? null,
+      categoryId: originalProduct.categoryId,
+    });
+
+    return product;
   }
 
   remove(id: string) {


### PR DESCRIPTION
## Summary
- extend event payloads with `product.created` and `product.updated`
- emit product events from `ProductsService`
- listen for product update events in new `ProductHistoryService`
- persist history entries via `ProductHistoryRepository`
- add ProductHistory module and register it
- wire event emitter into products module

## Testing
- `bun run lint` *(fails: Cannot find package '@eslint/js')*
- `bun run test` *(fails: jest: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2feaef60832b847e285e7186489b