### PR TITLE
Upload site config logo to MinIO

### DIFF
--- a/prisma/src/generated/dto/create-siteConfig.dto.ts
+++ b/prisma/src/generated/dto/create-siteConfig.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsIBAN, IsPhoneNumber, IsString, IsUUID } from 'class-validator';
+import { IsIBAN, IsPhoneNumber, IsString, IsUUID, IsOptional } from 'class-validator';
 
 export class CreateSiteConfigDto {
   @ApiProperty({
@@ -11,10 +11,11 @@ export class CreateSiteConfigDto {
 
   @ApiProperty({
     description: 'The logo path for the site configuration',
-    required: true,
+    required: false,
   })
   @IsString()
-  logoPath: string;
+  @IsOptional()
+  logoPath?: string;
 
   @ApiProperty({
     description: 'The email address for the site configuration',

--- a/src/site-config/site-config.module.ts
+++ b/src/site-config/site-config.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { SiteConfigService } from './site-config.service';
 import { SiteConfigController } from './site-config.controller';
 import { SiteConfigRepository } from './site-config.repository';
+import { FileRepositoryModule } from 'src/file-repository/file-repository.module';
 
 @Module({
+  imports: [FileRepositoryModule],
   controllers: [SiteConfigController],
   providers: [SiteConfigService, SiteConfigRepository],
 })

--- a/src/site-config/site-config.service.ts
+++ b/src/site-config/site-config.service.ts
@@ -3,13 +3,23 @@ import { SiteConfigRepository } from './site-config.repository';
 import { CreateSiteConfigDto } from 'prisma/src/generated/dto/create-siteConfig.dto';
 import { UpdateSiteConfigDto } from 'prisma/src/generated/dto/update-siteConfig.dto';
 import { SiteConfigDto } from 'prisma/src/generated/dto/siteConfig.dto';
-import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
+import { FileRepositoryService } from 'src/file-repository/file-repository.service';
 
 @Injectable()
 export class SiteConfigService {
-  constructor(private readonly siteConfigRepository: SiteConfigRepository) {}
+  constructor(
+    private readonly siteConfigRepository: SiteConfigRepository,
+    private readonly fileService: FileRepositoryService,
+  ) {}
 
-  create(createDto: CreateSiteConfigDto): Promise<SiteConfigDto> {
+  async create(
+    createDto: CreateSiteConfigDto,
+    file?: Express.Multer.File,
+  ): Promise<SiteConfigDto> {
+    if (file) {
+      const filename = await this.fileService.uploadFile(file);
+      createDto.logoPath = filename;
+    }
     return this.siteConfigRepository.create(createDto);
   }
 
@@ -21,7 +31,15 @@ export class SiteConfigService {
     return this.siteConfigRepository.findById(id);
   }
 
-  update(id: string, updateDto: UpdateSiteConfigDto): Promise<SiteConfigDto> {
+  async update(
+    id: string,
+    updateDto: UpdateSiteConfigDto,
+    file?: Express.Multer.File,
+  ): Promise<SiteConfigDto> {
+    if (file) {
+      const filename = await this.fileService.uploadFile(file);
+      updateDto.logoPath = filename;
+    }
     return this.siteConfigRepository.update(id, updateDto);
   }
 }


### PR DESCRIPTION
## Summary
- allow `logoPath` to be optional when creating site config
- integrate `FileRepositoryModule` to `SiteConfigModule`
- upload site config logo to MinIO in service
- accept multipart file in site config controller

## Testing
- `bun run lint` *(fails: 79 problems)*
- `bunx jest --runInBand` *(fails to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_687f5775fe3c832b8ae170eb3a3c7d18