### PR TITLE
Add missing resource tests

### DIFF
--- a/src/addresses/addresses.controller.spec.ts
+++ b/src/addresses/addresses.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AddressesController } from './addresses.controller';
+import { AddressesService } from './addresses.service';
+
+describe('AddressesController', () => {
+  let controller: AddressesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AddressesController],
+      providers: [AddressesService],
+    }).compile();
+
+    controller = module.get<AddressesController>(AddressesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/addresses/addresses.service.spec.ts
+++ b/src/addresses/addresses.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AddressesService } from './addresses.service';
+
+describe('AddressesService', () => {
+  let service: AddressesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AddressesService],
+    }).compile();
+
+    service = module.get<AddressesService>(AddressesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [AuthService],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuthService],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/event-emitter/typed-event-emitter.class.spec.ts
+++ b/src/event-emitter/typed-event-emitter.class.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypedEventEmitter } from './typed-event-emitter.class';
+
+describe('TypedEventEmitter', () => {
+  let service: TypedEventEmitter;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TypedEventEmitter],
+    }).compile();
+
+    service = module.get<TypedEventEmitter>(TypedEventEmitter);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/invoices/invoices.controller.spec.ts
+++ b/src/invoices/invoices.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InvoicesController } from './invoices.controller';
+import { InvoicesService } from './invoices.service';
+
+describe('InvoicesController', () => {
+  let controller: InvoicesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InvoicesController],
+      providers: [InvoicesService],
+    }).compile();
+
+    controller = module.get<InvoicesController>(InvoicesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/invoices/invoices.service.spec.ts
+++ b/src/invoices/invoices.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InvoicesService } from './invoices.service';
+
+describe('InvoicesService', () => {
+  let service: InvoicesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [InvoicesService],
+    }).compile();
+
+    service = module.get<InvoicesService>(InvoicesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/minio/minio.module.spec.ts
+++ b/src/minio/minio.module.spec.ts
@@ -1,0 +1,16 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MinioModule } from './minio.module';
+
+describe('MinioModule', () => {
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [MinioModule],
+    }).compile();
+  });
+
+  it('should be defined', () => {
+    expect(module).toBeDefined();
+  });
+});

--- a/src/product-history/product-history.service.spec.ts
+++ b/src/product-history/product-history.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductHistoryService } from './product-history.service';
+
+describe('ProductHistoryService', () => {
+  let service: ProductHistoryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProductHistoryService],
+    }).compile();
+
+    service = module.get<ProductHistoryService>(ProductHistoryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/rbac/resources.enum.spec.ts
+++ b/src/rbac/resources.enum.spec.ts
@@ -1,0 +1,7 @@
+import { Resources } from './resources.enum';
+
+describe('Resources enum', () => {
+  it('should be defined', () => {
+    expect(Resources).toBeDefined();
+  });
+});

--- a/src/routes/routes.controller.spec.ts
+++ b/src/routes/routes.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoutesController } from './routes.controller';
+import { RoutesService } from './routes.service';
+
+describe('RoutesController', () => {
+  let controller: RoutesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RoutesController],
+      providers: [RoutesService],
+    }).compile();
+
+    controller = module.get<RoutesController>(RoutesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/routes/routes.service.spec.ts
+++ b/src/routes/routes.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoutesService } from './routes.service';
+
+describe('RoutesService', () => {
+  let service: RoutesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RoutesService],
+    }).compile();
+
+    service = module.get<RoutesService>(RoutesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/site-config/site-config.controller.spec.ts
+++ b/src/site-config/site-config.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SiteConfigController } from './site-config.controller';
+import { SiteConfigService } from './site-config.service';
+
+describe('SiteConfigController', () => {
+  let controller: SiteConfigController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SiteConfigController],
+      providers: [SiteConfigService],
+    }).compile();
+
+    controller = module.get<SiteConfigController>(SiteConfigController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/site-config/site-config.service.spec.ts
+++ b/src/site-config/site-config.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SiteConfigService } from './site-config.service';
+
+describe('SiteConfigService', () => {
+  let service: SiteConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SiteConfigService],
+    }).compile();
+
+    service = module.get<SiteConfigService>(SiteConfigService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add controller/service specs for addresses
- add controller/service specs for auth
- add typed event emitter spec
- add invoices specs
- add minio module spec
- add product history service spec
- add RBAC enum spec
- add routes specs
- add site config specs

## Testing
- `bun test` *(fails: Cannot resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f9126dce8832b933a1406277faa15