### PR TITLE
Add CRUD and repository tests

### DIFF
--- a/src/addresses/addresses.controller.spec.ts
+++ b/src/addresses/addresses.controller.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AddressesController } from './addresses.controller';
+import { AddressesService } from './addresses.service';
+
+const serviceMock = {
+  create: jest.fn(),
+  findAllPaging: jest.fn(),
+  findAll: jest.fn(),
+  findById: jest.fn(),
+  update: jest.fn(),
+};
+
+describe('AddressesController', () => {
+  let controller: AddressesController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AddressesController],
+      providers: [{ provide: AddressesService, useValue: serviceMock }],
+    }).compile();
+
+    controller = module.get<AddressesController>(AddressesController);
+  });
+
+  it('creates an address', () => {
+    const dto = { city: 'A' } as any;
+    controller.create(dto);
+    expect(serviceMock.create).toHaveBeenCalledWith(dto);
+  });
+
+  it('lists addresses with paging', () => {
+    controller.findAll(5, 1, 'foo');
+    expect(serviceMock.findAllPaging).toHaveBeenCalledWith(5, 1, 'foo');
+  });
+
+  it('lists all addresses', () => {
+    controller.findAllAddresses();
+    expect(serviceMock.findAll).toHaveBeenCalled();
+  });
+
+  it('gets address by id', () => {
+    controller.findOne('1');
+    expect(serviceMock.findById).toHaveBeenCalledWith('1');
+  });
+
+  it('updates an address', () => {
+    const dto = { city: 'B' } as any;
+    controller.update('1', dto);
+    expect(serviceMock.update).toHaveBeenCalledWith('1', dto);
+  });
+});

--- a/src/addresses/addresses.repository.spec.ts
+++ b/src/addresses/addresses.repository.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { AddressesRepository } from './addresses.repository';
+
+const prismaMock = {
+  client: {
+    address: {
+      create: jest.fn(),
+      paginate: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+};
+
+function createModule() {
+  return Test.createTestingModule({
+    providers: [
+      AddressesRepository,
+      { provide: 'PrismaService', useValue: prismaMock },
+    ],
+  }).compile();
+}
+
+describe('AddressesRepository', () => {
+  let repository: AddressesRepository;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await createModule();
+    repository = module.get<AddressesRepository>(AddressesRepository);
+  });
+
+  it('creates address', async () => {
+    const dto = { city: 'A' } as any;
+    prismaMock.client.address.create.mockResolvedValue(dto);
+    const result = await repository.create(dto);
+    expect(prismaMock.client.address.create).toHaveBeenCalledWith({ data: dto });
+    expect(result).toEqual(dto);
+  });
+
+  it('finds all addresses paging', async () => {
+    const expected = [ { id: 1 } ];
+    const withPages = jest.fn().mockResolvedValue([expected, { count: 1 }]);
+    prismaMock.client.address.paginate.mockReturnValue({ withPages });
+    const result = await repository.findAllPaging(10, 2, 'foo');
+    expect(prismaMock.client.address.paginate).toHaveBeenCalled();
+    expect(withPages).toHaveBeenCalledWith({ limit: 10, page: 2, includePageCount: true });
+    expect(result.data).toEqual(expected);
+  });
+
+  it('finds all addresses', async () => {
+    prismaMock.client.address.findMany.mockResolvedValue([]);
+    const result = await repository.findAll();
+    expect(prismaMock.client.address.findMany).toHaveBeenCalledWith({ where: { deleted: false } });
+    expect(result).toEqual([]);
+  });
+
+  it('finds address by id', async () => {
+    prismaMock.client.address.findUnique.mockResolvedValue({ id: 1 });
+    const result = await repository.findById('1');
+    expect(prismaMock.client.address.findUnique).toHaveBeenCalledWith({ where: { addressId: '1' } });
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it('throws when address not found', async () => {
+    prismaMock.client.address.findUnique.mockResolvedValue(null);
+    await expect(repository.findById('1')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('updates address', async () => {
+    prismaMock.client.address.findUnique.mockResolvedValue({ id: 1, city: 'A' });
+    prismaMock.client.address.update.mockResolvedValue({ id: 1, city: 'B' });
+    const result = await repository.update('1', { city: 'B' } as any);
+    expect(prismaMock.client.address.update).toHaveBeenCalledWith({ where: { addressId: '1' }, data: { city: 'B' } });
+    expect(result).toEqual({ id: 1, city: 'B' });
+  });
+
+  it('throws on no change', async () => {
+    prismaMock.client.address.findUnique.mockResolvedValue({ id: 1, city: 'A' });
+    await expect(repository.update('1', { city: 'A' } as any)).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/src/addresses/addresses.service.spec.ts
+++ b/src/addresses/addresses.service.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AddressesService } from './addresses.service';
+import { AddressesRepository } from './addresses.repository';
+
+describe('AddressesService', () => {
+  let service: AddressesService;
+  let repository: AddressesRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AddressesService,
+        {
+          provide: AddressesRepository,
+          useValue: {
+            create: jest.fn(),
+            findAllPaging: jest.fn(),
+            findAll: jest.fn(),
+            findById: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AddressesService>(AddressesService);
+    repository = module.get<AddressesRepository>(AddressesRepository);
+  });
+
+  it('creates a new address', async () => {
+    const dto = { streetName: 'Main' } as any;
+    (repository.create as jest.Mock).mockResolvedValue(dto);
+    const result = await service.create(dto);
+    expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(result).toBe(dto);
+  });
+
+  it('gets all addresses with paging', async () => {
+    const paging = { data: [], meta: {} } as any;
+    (repository.findAllPaging as jest.Mock).mockResolvedValue(paging);
+    const result = await service.findAllPaging(5, 1, 'foo');
+    expect(repository.findAllPaging).toHaveBeenCalledWith(5, 1, 'foo');
+    expect(result).toBe(paging);
+  });
+
+  it('gets all addresses', async () => {
+    const list = [] as any;
+    (repository.findAll as jest.Mock).mockResolvedValue(list);
+    const result = await service.findAll();
+    expect(repository.findAll).toHaveBeenCalled();
+    expect(result).toBe(list);
+  });
+
+  it('gets address by id', async () => {
+    const item = { id: '1' } as any;
+    (repository.findById as jest.Mock).mockResolvedValue(item);
+    const result = await service.findById('1');
+    expect(repository.findById).toHaveBeenCalledWith('1');
+    expect(result).toBe(item);
+  });
+
+  it('updates an address', async () => {
+    const dto = { city: 'Berlin' } as any;
+    (repository.update as jest.Mock).mockResolvedValue(dto);
+    const result = await service.update('1', dto);
+    expect(repository.update).toHaveBeenCalledWith('1', dto);
+    expect(result).toBe(dto);
+  });
+});

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [AuthService],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuthService],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/event-emitter/typed-event-emitter.class.spec.ts
+++ b/src/event-emitter/typed-event-emitter.class.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypedEventEmitter } from './typed-event-emitter.class';
+
+describe('TypedEventEmitter', () => {
+  let service: TypedEventEmitter;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TypedEventEmitter],
+    }).compile();
+
+    service = module.get<TypedEventEmitter>(TypedEventEmitter);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/invoices/invoices.controller.spec.ts
+++ b/src/invoices/invoices.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InvoicesController } from './invoices.controller';
+import { InvoicesService } from './invoices.service';
+
+describe('InvoicesController', () => {
+  let controller: InvoicesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InvoicesController],
+      providers: [InvoicesService],
+    }).compile();
+
+    controller = module.get<InvoicesController>(InvoicesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/invoices/invoices.repository.spec.ts
+++ b/src/invoices/invoices.repository.spec.ts
@@ -1,0 +1,80 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { InvoicesRepository } from './invoices.repository';
+
+const prismaMock = {
+  client: {
+    invoice: {
+      create: jest.fn(),
+      paginate: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+};
+
+async function createModule() {
+  return Test.createTestingModule({
+    providers: [
+      InvoicesRepository,
+      { provide: 'PrismaService', useValue: prismaMock },
+    ],
+  }).compile();
+}
+
+describe('InvoicesRepository', () => {
+  let repo: InvoicesRepository;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await createModule();
+    repo = module.get<InvoicesRepository>(InvoicesRepository);
+  });
+
+  it('creates invoice', async () => {
+    const dto = { orderId: '1' } as any;
+    prismaMock.client.invoice.findUnique.mockResolvedValue(null);
+    prismaMock.client.invoice.create.mockResolvedValue(dto);
+    const result = await repo.create(dto);
+    expect(prismaMock.client.invoice.create).toHaveBeenCalledWith({ data: dto });
+    expect(result).toEqual(dto);
+  });
+
+  it('throws on duplicate invoice', async () => {
+    prismaMock.client.invoice.findUnique.mockResolvedValue({ id: 1 });
+    await expect(repo.create({ orderId: '1' } as any)).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('lists invoices', async () => {
+    const withPages = jest.fn().mockResolvedValue([[{ id: 1 }], { count: 1 }]);
+    prismaMock.client.invoice.paginate.mockReturnValue({ withPages });
+    const result = await repo.findAll(5, 1);
+    expect(withPages).toHaveBeenCalledWith({ limit: 5, page: 1, includePageCount: true });
+    expect(result.data).toEqual([{ id: 1 }]);
+  });
+
+  it('finds by id', async () => {
+    prismaMock.client.invoice.findUnique.mockResolvedValue({ id: 1 });
+    const result = await repo.findById('1');
+    expect(prismaMock.client.invoice.findUnique).toHaveBeenCalledWith({ where: { invoiceId: '1' } });
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it('throws when invoice not found', async () => {
+    prismaMock.client.invoice.findUnique.mockResolvedValue(null);
+    await expect(repo.findById('2')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('updates invoice', async () => {
+    prismaMock.client.invoice.findUnique.mockResolvedValue({ id: 1, total: 5 });
+    prismaMock.client.invoice.update.mockResolvedValue({ id: 1, total: 6 });
+    const result = await repo.update('1', { total: 6 } as any);
+    expect(prismaMock.client.invoice.update).toHaveBeenCalledWith({ where: { invoiceId: '1' }, data: { total: 6 } });
+    expect(result).toEqual({ id: 1, total: 6 });
+  });
+
+  it('throws on update no change', async () => {
+    prismaMock.client.invoice.findUnique.mockResolvedValue({ id: 1, total: 5 });
+    await expect(repo.update('1', { total: 5 } as any)).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/src/invoices/invoices.service.spec.ts
+++ b/src/invoices/invoices.service.spec.ts
@@ -1,0 +1,59 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InvoicesService } from './invoices.service';
+import { InvoicesRepository } from './invoices.repository';
+
+describe('InvoicesService', () => {
+  let service: InvoicesService;
+  let repository: InvoicesRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InvoicesService,
+        {
+          provide: InvoicesRepository,
+          useValue: {
+            create: jest.fn(),
+            findAll: jest.fn(),
+            findById: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<InvoicesService>(InvoicesService);
+    repository = module.get<InvoicesRepository>(InvoicesRepository);
+  });
+
+  it('creates invoice', async () => {
+    const dto = { orderId: '1' } as any;
+    (repository.create as jest.Mock).mockResolvedValue(dto);
+    const result = await service.create(dto);
+    expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(result).toBe(dto);
+  });
+
+  it('lists invoices', async () => {
+    const res = { data: [], meta: {} } as any;
+    (repository.findAll as jest.Mock).mockResolvedValue(res);
+    const result = await service.findAll(5, 1);
+    expect(repository.findAll).toHaveBeenCalledWith(5, 1);
+    expect(result).toBe(res);
+  });
+
+  it('gets invoice by id', async () => {
+    (repository.findById as jest.Mock).mockResolvedValue({ id: 1 });
+    const result = await service.findById('1');
+    expect(repository.findById).toHaveBeenCalledWith('1');
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it('updates invoice', async () => {
+    (repository.update as jest.Mock).mockResolvedValue({ id: 1 });
+    const dto = { total: 10 } as any;
+    const result = await service.update('1', dto);
+    expect(repository.update).toHaveBeenCalledWith('1', dto);
+    expect(result).toEqual({ id: 1 });
+  });
+});

--- a/src/minio/minio.module.spec.ts
+++ b/src/minio/minio.module.spec.ts
@@ -1,0 +1,16 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MinioModule } from './minio.module';
+
+describe('MinioModule', () => {
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [MinioModule],
+    }).compile();
+  });
+
+  it('should be defined', () => {
+    expect(module).toBeDefined();
+  });
+});

--- a/src/product-history/product-history.service.spec.ts
+++ b/src/product-history/product-history.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductHistoryService } from './product-history.service';
+
+describe('ProductHistoryService', () => {
+  let service: ProductHistoryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProductHistoryService],
+    }).compile();
+
+    service = module.get<ProductHistoryService>(ProductHistoryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/rbac/resources.enum.spec.ts
+++ b/src/rbac/resources.enum.spec.ts
@@ -1,0 +1,7 @@
+import { Resources } from './resources.enum';
+
+describe('Resources enum', () => {
+  it('should be defined', () => {
+    expect(Resources).toBeDefined();
+  });
+});

--- a/src/routes/routes.controller.spec.ts
+++ b/src/routes/routes.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoutesController } from './routes.controller';
+import { RoutesService } from './routes.service';
+
+describe('RoutesController', () => {
+  let controller: RoutesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RoutesController],
+      providers: [RoutesService],
+    }).compile();
+
+    controller = module.get<RoutesController>(RoutesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/routes/routes.service.spec.ts
+++ b/src/routes/routes.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoutesService } from './routes.service';
+
+describe('RoutesService', () => {
+  let service: RoutesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RoutesService],
+    }).compile();
+
+    service = module.get<RoutesService>(RoutesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/site-config/site-config.controller.spec.ts
+++ b/src/site-config/site-config.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SiteConfigController } from './site-config.controller';
+import { SiteConfigService } from './site-config.service';
+
+describe('SiteConfigController', () => {
+  let controller: SiteConfigController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SiteConfigController],
+      providers: [SiteConfigService],
+    }).compile();
+
+    controller = module.get<SiteConfigController>(SiteConfigController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/site-config/site-config.service.spec.ts
+++ b/src/site-config/site-config.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SiteConfigService } from './site-config.service';
+
+describe('SiteConfigService', () => {
+  let service: SiteConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SiteConfigService],
+    }).compile();
+
+    service = module.get<SiteConfigService>(SiteConfigService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add CRUD tests for addresses service
- add addresses controller tests for endpoints
- add repository tests for addresses
- add CRUD tests for invoices service
- add repository tests for invoices

## Testing
- `bun test` *(fails: Cannot find module '@nestjs/testing')*

------
https://chatgpt.com/codex/tasks/task_e_687f9126dce8832b933a1406277faa15