### PR TITLE
Add optional OTP inclusion for employee lookup

### DIFF
--- a/src/employees/employees.controller.ts
+++ b/src/employees/employees.controller.ts
@@ -132,8 +132,19 @@ export class EmployeesController {
   }
 
   @Get(':employeeId')
-  findById(@Param('employeeId', ParseUUIDPipe) employeeId: string) {
-    return this.employeesService.findById(employeeId);
+  @ApiQuery({
+    name: 'includeOtp',
+    required: false,
+    type: Boolean,
+    example: true,
+    description: 'Include OTP data in the response',
+  })
+  findById(
+    @Param('employeeId', ParseUUIDPipe) employeeId: string,
+    @Query('includeOtp') includeOtp?: string,
+  ) {
+    const withOtp = includeOtp === 'true';
+    return this.employeesService.findById(employeeId, withOtp);
   }
 
   @Patch(':employeeId')

--- a/src/employees/employees.repository.ts
+++ b/src/employees/employees.repository.ts
@@ -112,10 +112,13 @@ export class EmployeesRepository {
     };
   }
 
-  async findById(employeeId: string) {
-    const employee =
-      await this.prismaService.client.employees.findById(employeeId);
-    return transformResponse(EmployeesDto, employee);
+  async findById(employeeId: string, includeOtp = false) {
+    const employee = await this.prismaService.client.employees.findUnique({
+      where: { employeeId },
+      ...(includeOtp && { include: { Otp: true } }),
+    });
+    const base = transformResponse(EmployeesDto, employee);
+    return includeOtp ? { ...base, Otp: employee?.Otp } : base;
   }
 
   async findByRole(role: string) {

--- a/src/employees/employees.service.ts
+++ b/src/employees/employees.service.ts
@@ -46,8 +46,8 @@ export class EmployeesService {
     return this.employeesRepository.findAll(page, limit, search, permissions);
   }
 
-  findById(id: string) {
-    return this.employeesRepository.findById(id);
+  findById(id: string, includeOtp = false) {
+    return this.employeesRepository.findById(id, includeOtp);
   }
 
   findByEmail(email: string) {

--- a/src/otp/dto/otp.dto.ts
+++ b/src/otp/dto/otp.dto.ts
@@ -1,0 +1,21 @@
+import { Expose } from 'class-transformer';
+
+export class OtpDto {
+  @Expose()
+  id: string;
+
+  @Expose()
+  code: string;
+
+  @Expose()
+  employeeId: string;
+
+  @Expose()
+  expiresAt: Date;
+
+  @Expose()
+  used: boolean;
+
+  @Expose()
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- allow fetching OTP info when retrieving an employee
- return OTP info from repository when requested
- expose new `OtpDto`

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: Cannot find module '.prisma/client/default')*

------
https://chatgpt.com/codex/tasks/task_e_688093f0ddac832b83e4f708063ef841