### PR TITLE
feat: switch to fastify adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@fastify/multipart": "^9.0.3",
     "@fastify/static": "^8.2.0",
     "@fastify/swagger": "9.5.1",
+    "@fastify/swagger-ui": "^5.2.3",
     "@keyv/redis": "^4.6.0",
     "@nestjs-modules/mailer": "^2.0.2",
     "@nestjs/cache-manager": "^3.0.1",
@@ -55,7 +56,6 @@
     "class-validator": "^0.14.2",
     "commander": "^14.0.0",
     "fastify-helmet": "^7.1.0",
-    "fastify-swagger": "^5.2.0",
     "keyv": "^5.4.0",
     "minio": "^8.0.5",
     "mqtt": "^5.13.3",
@@ -69,11 +69,10 @@
     "passport-local": "^1.0.0",
     "prisma-extension-pagination": "^0.7.5",
     "prisma-generator-nestjs-dto": "^1.1.4",
-    "redoc-express": "^2.1.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "slugify": "^1.6.6",
-    "swagger-ui-express": "^5.0.1"
+    "slugify": "^1.6.6"
+    
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
@@ -84,7 +83,6 @@
     "@nestjs/testing": "^11.1.5",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.13.2",
-    "@types/express": "^5.0.3",
     "@types/jest": "^29.5.14",
     "@types/k6": "^1.1.1",
     "@types/node": "^22.16.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@fastify/swagger':
         specifier: 9.5.1
         version: 9.5.1
+      '@fastify/swagger-ui':
+        specifier: ^5.2.3
+        version: 5.2.3
       '@keyv/redis':
         specifier: ^4.6.0
         version: 4.6.0(keyv@5.4.0)
@@ -107,9 +110,6 @@ importers:
       fastify-helmet:
         specifier: ^7.1.0
         version: 7.1.0
-      fastify-swagger:
-        specifier: ^5.2.0
-        version: 5.2.0
       keyv:
         specifier: ^5.4.0
         version: 5.4.0
@@ -149,9 +149,6 @@ importers:
       prisma-generator-nestjs-dto:
         specifier: ^1.1.4
         version: 1.1.4
-      redoc-express:
-        specifier: ^2.1.0
-        version: 2.1.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -161,9 +158,6 @@ importers:
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
-      swagger-ui-express:
-        specifier: ^5.0.1
-        version: 5.0.1(express@5.1.0)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -189,9 +183,6 @@ importers:
       '@swc/core':
         specifier: ^1.13.2
         version: 1.13.2
-      '@types/express':
-        specifier: ^5.0.3
-        version: 5.0.3
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -640,6 +631,9 @@ packages:
 
   '@fastify/static@8.2.0':
     resolution: {integrity: sha512-PejC/DtT7p1yo3p+W7LiUtLMsV8fEvxAK15sozHy9t8kwo5r0uLYmhV/inURmGz1SkHZFz/8CNtHLPyhKcx4SQ==}
+
+  '@fastify/swagger-ui@5.2.3':
+    resolution: {integrity: sha512-e7ivEJi9EpFcxTONqICx4llbpB2jmlI+LI1NQ/mR7QGQnyDOqZybPK572zJtcdHZW4YyYTBHcP3a03f1pOh0SA==}
 
   '@fastify/swagger@9.5.1':
     resolution: {integrity: sha512-EGjYLA7vDmCPK7XViAYMF6y4+K3XUy5soVTVxsyXolNe/Svb4nFQxvtuQvvoQb2Gzc9pxiF3+ZQN/iZDHhKtTg==}
@@ -2426,14 +2420,6 @@ packages:
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
-  debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -2502,10 +2488,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  depd@1.1.2:
-    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
-    engines: {node: '>= 0.6'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2513,9 +2495,6 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  destroy@1.0.4:
-    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -2629,10 +2608,6 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  encodeurl@1.0.2:
-    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
-    engines: {node: '>= 0.8'}
-
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -2640,10 +2615,6 @@ packages:
   encoding-japanese@2.2.0:
     resolution: {integrity: sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==}
     engines: {node: '>=8.10.0'}
-
-  encoding-negotiator@2.0.1:
-    resolution: {integrity: sha512-GSK7qphNR4iPcejfAlZxKDoz3xMhnspwImK+Af5WhePS9jUpK/Oh7rUdyENWu+9rgDflOCTmAojBsgsvM8neAQ==}
-    engines: {node: '>=10.13.0'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2918,20 +2889,6 @@ packages:
   fastify-plugin@5.0.1:
     resolution: {integrity: sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==}
 
-  fastify-static@4.6.1:
-    resolution: {integrity: sha512-vy7N28U4AMhuOim12ZZWHulEE6OQKtzZbHgiB8Zj4llUuUQXPka0WHAQI3njm1jTCx4W6fixUHfpITxweMtAIA==}
-
-  fastify-static@4.7.0:
-    resolution: {integrity: sha512-zZhCfJv/hkmud2qhWqpU3K9XVAuy3+IV8Tp9BC5J5U+GyA2XwoB6h8lh9GqpEIqdXOw01WyWQllV7dOWVyAlXg==}
-    deprecated: Please use @fastify/static@5.0.0 instead
-
-  fastify-swagger@5.1.1:
-    resolution: {integrity: sha512-7DA0zS8CCV5r+gbLgWdeeKEwLrVbbOxLMJVUfOl1H9+wSildSLD8hok2TLX7s3c28wOjF8+iZRxsz/hBDzfdIw==}
-
-  fastify-swagger@5.2.0:
-    resolution: {integrity: sha512-yKct50Mev9YIrhd2FRO4AChcJM9JwTBCziIjA4C+AI+hV2ystaIklgHVEwHoyqlaeQ+B4gZ1Z5rgOE87i4llLg==}
-    deprecated: Please use @fastify/swagger@6.0.0 instead
-
   fastify@5.4.0:
     resolution: {integrity: sha512-I4dVlUe+WNQAhKSyv15w+dwUh2EPiEl4X2lGYMmNSgF83WzTMAPKGdWEv5tPsCQOb+SOZwz8Vlta2vF+OeDgRw==}
 
@@ -3047,10 +3004,6 @@ packages:
 
   fp-ts@2.12.1:
     resolution: {integrity: sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw==}
-
-  fresh@0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
-    engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -3260,10 +3213,6 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
-
-  http-errors@1.8.1:
-    resolution: {integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==}
-    engines: {node: '>= 0.6'}
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -3688,10 +3637,6 @@ packages:
   json-schema-ref-resolver@2.0.1:
     resolution: {integrity: sha512-HG0SIB9X4J8bwbxCbnd5FfPEbcXAJYTi1pBJeP/QPON+w8ovSME8iRG+ElHNxZNX2Qh6eYn1GdzJFS4cDFfx0Q==}
 
-  json-schema-resolver@1.3.0:
-    resolution: {integrity: sha512-EX7W1r8aZ/T3j8GbbBxPXi60bnsELfT90OiA1QrbGMvwzVSbyMNOAzvMFcFb8m7gKCXZLJpGe+cJOvWgoFl29A==}
-    engines: {node: '>=10'}
-
   json-schema-resolver@3.0.0:
     resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
     engines: {node: '>=20'}
@@ -3954,11 +3899,6 @@ packages:
     resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
-  mime@1.6.0:
-    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
@@ -4147,9 +4087,6 @@ packages:
     engines: {node: '>=16.0.0'}
     hasBin: true
 
-  ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -4293,10 +4230,6 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
-  on-finished@2.3.0:
-    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
-    engines: {node: '>= 0.8'}
-
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -4311,9 +4244,6 @@ packages:
   open@7.4.2:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
     engines: {node: '>=8'}
-
-  openapi-types@10.0.0:
-    resolution: {integrity: sha512-Y8xOCT2eiKGYDzMW9R4x5cmfc3vGaaI4EL2pwhDmodWw1HlK18YcZ4uJxc7Rdp7/gGzAygzH9SXr6GKYIXbRcQ==}
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
@@ -4713,9 +4643,6 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
-  redoc-express@2.1.0:
-    resolution: {integrity: sha512-gq6FvghNirD3dCJ7w8Z6escXYHnU1Hk50baQsIeGunQQ9YRoy6qR/MjEOJtDEKaPNB2NgkIzQ9ESNX5/27zkDA==}
-
   reflect-metadata@0.1.14:
     resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
 
@@ -4892,10 +4819,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@0.17.2:
-    resolution: {integrity: sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==}
-    engines: {node: '>= 0.8.0'}
-
   send@1.2.0:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
@@ -5061,10 +4984,6 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
-  statuses@1.5.0:
-    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
-    engines: {node: '>= 0.6'}
-
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -5180,15 +5099,6 @@ packages:
 
   swagger-ui-dist@5.21.0:
     resolution: {integrity: sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==}
-
-  swagger-ui-dist@5.27.0:
-    resolution: {integrity: sha512-tS6LRyBhY6yAqxrfsA9IYpGWPUJOri6sclySa7TdC7XQfGLvTwDY531KLgfQwHEtQsn+sT4JlUspbeQDBVGWig==}
-
-  swagger-ui-express@5.0.1:
-    resolution: {integrity: sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==}
-    engines: {node: '>= v0.10.32'}
-    peerDependencies:
-      express: '>=4.0.0 || >=5.0.0-beta'
 
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
@@ -6225,6 +6135,14 @@ snapshots:
       fastify-plugin: 5.0.1
       fastq: 1.19.1
       glob: 11.0.3
+
+  '@fastify/swagger-ui@5.2.3':
+    dependencies:
+      '@fastify/static': 8.2.0
+      fastify-plugin: 5.0.1
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.0
 
   '@fastify/swagger@9.5.1':
     dependencies:
@@ -8406,10 +8324,6 @@ snapshots:
 
   dayjs@1.11.13: {}
 
-  debug@2.6.9:
-    dependencies:
-      ms: 2.0.0
-
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
@@ -8460,13 +8374,9 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  depd@1.1.2: {}
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
-
-  destroy@1.0.4: {}
 
   detect-indent@6.1.0:
     optional: true
@@ -8588,14 +8498,10 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  encodeurl@1.0.2: {}
-
   encodeurl@2.0.0: {}
 
   encoding-japanese@2.2.0:
     optional: true
-
-  encoding-negotiator@2.0.1: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -8922,43 +8828,6 @@ snapshots:
 
   fastify-plugin@5.0.1: {}
 
-  fastify-static@4.6.1:
-    dependencies:
-      content-disposition: 0.5.4
-      encoding-negotiator: 2.0.1
-      fastify-plugin: 3.0.1
-      glob: 7.2.3
-      p-limit: 3.1.0
-      readable-stream: 3.6.2
-      send: 0.17.2
-    transitivePeerDependencies:
-      - supports-color
-
-  fastify-static@4.7.0:
-    dependencies:
-      fastify-static-deprecated: fastify-static@4.6.1
-      process-warning: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  fastify-swagger@5.1.1:
-    dependencies:
-      fastify-plugin: 3.0.1
-      fastify-static: 4.7.0
-      js-yaml: 4.1.0
-      json-schema-resolver: 1.3.0
-      openapi-types: 10.0.0
-      rfdc: 1.4.1
-    transitivePeerDependencies:
-      - supports-color
-
-  fastify-swagger@5.2.0:
-    dependencies:
-      fastify-swagger-deprecated: fastify-swagger@5.1.1
-      process-warning: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   fastify@5.4.0:
     dependencies:
       '@fastify/ajv-compiler': 4.0.2
@@ -9133,8 +9002,6 @@ snapshots:
   forwarded@0.2.0: {}
 
   fp-ts@2.12.1: {}
-
-  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -9382,14 +9249,6 @@ snapshots:
     optional: true
 
   http-cache-semantics@4.2.0: {}
-
-  http-errors@1.8.1:
-    dependencies:
-      depd: 1.1.2
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 1.5.0
-      toidentifier: 1.0.1
 
   http-errors@2.0.0:
     dependencies:
@@ -9989,14 +9848,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  json-schema-resolver@1.3.0:
-    dependencies:
-      debug: 4.4.1
-      rfdc: 1.4.1
-      uri-js: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.1
@@ -10264,8 +10115,6 @@ snapshots:
   mime-types@3.0.1:
     dependencies:
       mime-db: 1.54.0
-
-  mime@1.6.0: {}
 
   mime@2.6.0: {}
 
@@ -10715,8 +10564,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  ms@2.0.0: {}
-
   ms@2.1.2: {}
 
   ms@2.1.3: {}
@@ -10852,10 +10699,6 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
-  on-finished@2.3.0:
-    dependencies:
-      ee-first: 1.1.1
-
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -10872,8 +10715,6 @@ snapshots:
     dependencies:
       is-docker: 2.2.1
       is-wsl: 2.2.0
-
-  openapi-types@10.0.0: {}
 
   openapi-types@12.1.3: {}
 
@@ -11343,8 +11184,6 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  redoc-express@2.1.0: {}
-
   reflect-metadata@0.1.14: {}
 
   reflect-metadata@0.2.2: {}
@@ -11499,24 +11338,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.2: {}
-
-  send@0.17.2:
-    dependencies:
-      debug: 2.6.9
-      depd: 1.1.2
-      destroy: 1.0.4
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 1.8.1
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.3.0
-      range-parser: 1.2.1
-      statuses: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   send@1.2.0:
     dependencies:
@@ -11696,8 +11517,6 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
-  statuses@1.5.0: {}
-
   statuses@2.0.1: {}
 
   statuses@2.0.2: {}
@@ -11820,15 +11639,6 @@ snapshots:
   swagger-ui-dist@5.21.0:
     dependencies:
       '@scarf/scarf': 1.4.0
-
-  swagger-ui-dist@5.27.0:
-    dependencies:
-      '@scarf/scarf': 1.4.0
-
-  swagger-ui-express@5.0.1(express@5.1.0):
-    dependencies:
-      express: 5.1.0
-      swagger-ui-dist: 5.27.0
 
   symbol-observable@4.0.0: {}
 

--- a/src/auth/guards/RBACGuard.ts
+++ b/src/auth/guards/RBACGuard.ts
@@ -6,7 +6,7 @@ import {
   Inject,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { Request } from 'express';
+import { FastifyRequest } from 'fastify';
 import { CustomPrismaService } from 'nestjs-prisma';
 import { ExtendedPrismaClient } from 'prisma/prisma.extension';
 import { Actions } from '@prisma/client';
@@ -24,7 +24,7 @@ export class PermissionsGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const req = context.switchToHttp().getRequest<Request>();
+    const req = context.switchToHttp().getRequest<FastifyRequest>();
     const employee = req.user as JwtPayload;
 
     const method = req.method;

--- a/src/auth/guards/max-employee.guard.ts
+++ b/src/auth/guards/max-employee.guard.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { TenantsService } from 'src/tenants/tenants.service';
 import { JwtPayload } from '../auth.service';
-import { Request } from 'express';
+import { FastifyRequest } from 'fastify';
 import { CustomPrismaService } from 'nestjs-prisma/dist/custom';
 import { ExtendedPrismaClient } from 'prisma/prisma.extension';
 
@@ -20,7 +20,7 @@ export class MaxEmployeeGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const req = context.switchToHttp().getRequest<Request>();
+    const req = context.switchToHttp().getRequest<FastifyRequest>();
     const employee = req.user as JwtPayload;
     const method = req.method;
 

--- a/src/auth/guards/modules.guard.ts
+++ b/src/auth/guards/modules.guard.ts
@@ -9,7 +9,7 @@ import { Reflector } from '@nestjs/core';
 import { ModuleEnum } from 'src/tenants/dto/modules-entity.dto';
 import { TenantsService } from 'src/tenants/tenants.service';
 import { JwtPayload } from '../auth.service';
-import { Request } from 'express';
+import { FastifyRequest } from 'fastify';
 import { MODULE_KEY } from 'lib/decorators/module.decorators';
 
 @Injectable()
@@ -20,7 +20,7 @@ export class ModulesGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const req = context.switchToHttp().getRequest<Request>();
+    const req = context.switchToHttp().getRequest<FastifyRequest>();
     const employee = req.user as JwtPayload;
 
     console.log(

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,23 @@ import { NestFactory, Reflector } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import fastifyMultipart from '@fastify/multipart';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestFastifyApplication>(
+    AppModule,
+    new FastifyAdapter(),
+  );
+
+  await app.register(fastifyMultipart);
+
   app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
+
   // Swagger setup
   const config = new DocumentBuilder()
     .setTitle('API Documentation')
@@ -18,9 +30,11 @@ async function bootstrap() {
       in: 'header',
     })
     .build();
+
   const document = SwaggerModule.createDocument(app, config);
-  // Optionally test Swagger UI
   SwaggerModule.setup('docs', app, document);
-  await app.listen(process.env.PORT ?? 3001);
+
+  await app.listen(process.env.PORT ?? 3001, '0.0.0.0');
 }
+
 bootstrap();

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -28,7 +28,7 @@ import { Resources } from '../rbac/resources.enum';
 import { Resource } from 'lib/decorators/resource.decorator';
 import { CreateProductDto } from 'src/products/dto/create-product.dto';
 import { UpdateProductDto } from 'src/products/dto/update-product.dto';
-import { FileInterceptor } from '@nestjs/platform-express';
+import { FileInterceptor, MemoryStorageFile } from '@blazity/nest-file-fastify';
 import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
 import { ProductDto } from './dto/product.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
@@ -64,7 +64,7 @@ export class ProductsController {
   @UseInterceptors(FileInterceptor('productImage'))
   create(
     @Body() createProductDto: CreateProductDto,
-    @UploadedFile() file: Express.Multer.File,
+    @UploadedFile() file: MemoryStorageFile,
   ) {
     console.log('Received product data:', createProductDto);
     console.log('Received file:', file);
@@ -158,7 +158,7 @@ export class ProductsController {
   update(
     @Param('productId', ParseUUIDPipe) productId: string,
     @Body() updateProductDto: UpdateProductDto,
-    @UploadedFile() file: Express.Multer.File,
+    @UploadedFile() file: MemoryStorageFile,
   ) {
     return this.productsService.update(productId, updateProductDto, file);
   }

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -8,6 +8,7 @@ import { PagingResultDto } from 'lib/dto/genericPagingResultDto';
 import { ProductDto } from './dto/product.dto';
 import { TypedEventEmitter } from 'src/event-emitter/typed-event-emitter.class';
 import { ProductHistoryDto } from './dto/product-history';
+import { MemoryStorageFile } from '@blazity/nest-file-fastify';
 
 @Injectable()
 export class ProductsService {
@@ -17,7 +18,7 @@ export class ProductsService {
     private readonly eventEmitter: TypedEventEmitter,
   ) {}
   // products.service.ts
-  async create(createProductDto: CreateProductDto, file: Express.Multer.File) {
+  async create(createProductDto: CreateProductDto, file: MemoryStorageFile) {
     let imageFilename: string | undefined;
 
     if (file) {
@@ -104,7 +105,7 @@ export class ProductsService {
   async update(
     id: string,
     updateProductDto: UpdateProductDto,
-    file: Express.Multer.File,
+    file: MemoryStorageFile,
   ) {
     let imageFilename: string | undefined;
 

--- a/src/site-config/site-config.controller.ts
+++ b/src/site-config/site-config.controller.ts
@@ -28,7 +28,7 @@ import { PermissionsGuard } from 'src/auth/guards/RBACGuard';
 import { CreateSiteConfigDto } from 'prisma/src/generated/dto/create-siteConfig.dto';
 import { UpdateSiteConfigDto } from 'prisma/src/generated/dto/update-siteConfig.dto';
 import { SiteConfigDto } from 'prisma/src/generated/dto/siteConfig.dto';
-import { FileInterceptor } from '@nestjs/platform-express';
+import { FileInterceptor, MemoryStorageFile } from '@blazity/nest-file-fastify';
 import { SiteConfigWithTenantDto } from './dto/siteConfig-with-tenant.dto';
 
 @Controller('site-config')
@@ -51,7 +51,7 @@ export class SiteConfigController {
   @UseInterceptors(FileInterceptor('logoPath'))
   create(
     @Body() createDto: CreateSiteConfigDto,
-    @UploadedFile() file: Express.Multer.File,
+    @UploadedFile() file: MemoryStorageFile,
   ) {
     return this.siteConfigService.create(createDto, file);
   }
@@ -78,7 +78,7 @@ export class SiteConfigController {
   update(
     @Param('siteConfigId', ParseUUIDPipe) siteConfigId: string,
     @Body() updateDto: UpdateSiteConfigDto,
-    @UploadedFile() file: Express.Multer.File,
+    @UploadedFile() file: MemoryStorageFile,
   ) {
     return this.siteConfigService.update(siteConfigId, updateDto, file);
   }

--- a/src/site-config/site-config.service.ts
+++ b/src/site-config/site-config.service.ts
@@ -7,6 +7,7 @@ import { FileRepositoryService } from 'src/file-repository/file-repository.servi
 import { Tenant } from 'src/tenants/entities/tenant.entity';
 import { TenantDto } from 'src/tenants/dto/tenant-entity.dto';
 import { TenantsService } from 'src/tenants/tenants.service';
+import { MemoryStorageFile } from '@blazity/nest-file-fastify';
 
 @Injectable()
 export class SiteConfigService {
@@ -18,7 +19,7 @@ export class SiteConfigService {
 
   async create(
     createDto: CreateSiteConfigDto,
-    file?: Express.Multer.File,
+    file?: MemoryStorageFile,
   ): Promise<SiteConfigDto> {
     if (file) {
       const filename = await this.fileService.uploadFile(file);
@@ -58,7 +59,7 @@ export class SiteConfigService {
   async update(
     id: string,
     updateDto: UpdateSiteConfigDto,
-    file?: Express.Multer.File,
+    file?: MemoryStorageFile,
   ): Promise<SiteConfigDto> {
     if (file) {
       const filename = await this.fileService.uploadFile(file);

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,18 +1,22 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
 import * as request from 'supertest';
-import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication<App>;
+  let app: NestFastifyApplication;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
     await app.init();
   });
 


### PR DESCRIPTION
## Summary
- use Fastify as Nest backend adapter
- replace Express-specific file upload code with Fastify-compatible interceptors
- update test bootstrapping and dependencies for Fastify

## Testing
- `pnpm lint` *(fails: Unsafe member access...)*
- `pnpm test` *(fails: Cannot find module '.prisma/client/default'...)*

------
https://chatgpt.com/codex/tasks/task_e_688f28325b3c832b8992b40fc74d040e