### PR TITLE
fix: avoid duplicate multipart plugin

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -66,6 +66,11 @@ import { FastifyMulterModule } from '@nest-lab/fastify-multer';
       isGlobal: true, // Makes ConfigService globally available
       envFilePath: '.env', // Default
     }),
+    FastifyMulterModule.register({
+      limits: {
+        fileSize: 10 * 1024 * 1024,
+      },
+    }),
     EmailModule,
     CustomersModule,
     AuthModule,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,3 @@
-import { fastifyMultipart } from '@fastify/multipart';
 import { NestFactory, Reflector } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
@@ -13,12 +12,6 @@ async function bootstrap() {
     AppModule,
     new FastifyAdapter(),
   );
-  await app.register(fastifyMultipart, {
-    limits: {
-      fileSize: 10 * 1024 * 1024, // z. B. 10MB
-    },
-  });
-
   app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 

--- a/src/products/products.module.ts
+++ b/src/products/products.module.ts
@@ -4,10 +4,9 @@ import { ProductsController } from './products.controller';
 import { ProductsRepository } from './products.repository';
 import { FileRepositoryModule } from 'src/file-repository/file-repository.module';
 import { TypedEventEmitterModule } from 'src/event-emitter/event-emitter.module';
-import { FastifyMulterModule } from '@nest-lab/fastify-multer';
 
 @Module({
-  imports: [FileRepositoryModule, TypedEventEmitterModule, FastifyMulterModule],
+  imports: [FileRepositoryModule, TypedEventEmitterModule],
   controllers: [ProductsController],
   providers: [ProductsService, ProductsRepository],
   exports: [ProductsService, ProductsRepository],


### PR DESCRIPTION
## Summary
- avoid double registration of multipart parser
- configure FastifyMulterModule globally with 10 MB limit

## Testing
- `pnpm lint` *(fails: 710 problems)*
- `pnpm test` *(fails: cannot find module '.prisma/client/default')*

------
https://chatgpt.com/codex/tasks/task_e_688f5ad5ead8832b82b5cf6443c288e9